### PR TITLE
fix(ci): respect app pnpm version in Avatar deploy

### DIFF
--- a/.github/workflows/deploy-avatar.yml
+++ b/.github/workflows/deploy-avatar.yml
@@ -55,8 +55,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.28.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- remove the hardcoded pnpm 10.28.0 override from the Avatar Pages workflow
- let pnpm/action-setup read the checked-out app repository packageManager (pnpm 11.7.0)

## Verification
- git diff --check
- verified app main packageManager is pnpm@11.7.0

## Experience Review
- [x] `$post-task-experience-review` not applicable: this is a two-line CI configuration correction with no reusable implementation lesson.