### PR TITLE
fix(ci): declare Avatar pnpm toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@oneworks/avatar-assets",
   "type": "module",
   "version": "0.1.0-alpha.0",
+  "packageManager": "pnpm@11.7.0",
   "private": true,
   "description": "OneWorks pixel-rect avatar previews and SVG assets",
   "repository": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true


### PR DESCRIPTION
## Summary
- declare pnpm@11.7.0 in the independent Avatar repository
- keep pnpm/action-setup version-free so it follows the repository toolchain contract

## Verification
- `git diff --check`
- `pnpm install --frozen-lockfile` accepted the pnpm lockfile under pnpm 11.7.0; dependency postinstall execution was blocked only by the local supply-chain approval policy
- fixed-RC-source workflow build had already passed on the independent build design: https://github.com/oneworks-ai/avatar/actions/runs/30756470822

## Experience Review
- [x] `$post-task-experience-review` not applicable: small CI metadata correction; no stable reusable code-pattern lesson.