### PR TITLE
feat: add public 3D avatar runtime adapters

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -57,11 +57,14 @@ jobs:
       - name: Test editor and runtime contracts
         run: pnpm test
 
-      - name: Typecheck app and SDK packages
-        run: pnpm typecheck && pnpm --filter './packages/*' typecheck
+      - name: Typecheck app source
+        run: pnpm typecheck
 
-      - name: Build app and SDK packages
-        run: pnpm build:app-source && pnpm build:sdk
+      - name: Build and typecheck SDK packages
+        run: pnpm typecheck:sdk
+
+      - name: Build app source
+        run: pnpm build:app-source
 
       - name: Test packed packages in a clean consumer
         run: pnpm smoke:sdk

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -1,0 +1,70 @@
+name: Avatar SDK CI
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/sdk-ci.yml
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - packages/**
+      - scripts/**
+      - src/**
+      - tsconfig*.json
+      - vite.config.ts
+      - vitest.config.ts
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  sdk:
+    name: build-test-pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout Avatar repository
+        uses: actions/checkout@v4
+
+      - name: Checkout shared OneWorks sources
+        uses: actions/checkout@v4
+        with:
+          repository: oneworks-ai/app
+          path: app-source
+          submodules: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.7.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: app-source/.node-version
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test editor and runtime contracts
+        run: pnpm test
+
+      - name: Typecheck app and SDK packages
+        run: pnpm typecheck && pnpm --filter './packages/*' typecheck
+
+      - name: Build app and SDK packages
+        run: pnpm build:app-source && pnpm build:sdk
+
+      - name: Test packed packages in a clean consumer
+        run: pnpm smoke:sdk
+
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level high

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ This project is the preview/export surface for the OneWorks avatar visual system
 - `src/App.tsx`: standalone preview/export surface.
 - `src/App.scss`: page layout and interaction styling.
 - `.github/workflows/deploy-avatar.yml`: GitHub Pages deployment owned by the `oneworks-ai/avatar` repository.
+- `packages/core/`: versioned framework-neutral 3D scene definitions and animation runtime.
+- `packages/react/`: React renderer and the embeddable full editor; it is the single framework adapter allowed to import editor internals.
+- `packages/web/`: Vanilla JS mounts and opt-in custom elements built on the React adapter.
+- `packages/vue/`: Vue components built on the Vanilla JS mounts so rendering behavior remains identical across frameworks.
 - `skills/oneworks-avatar/`: installable Agent Skill for 3D authoring, debugging, export verification, and current developer-integration boundaries.
 
 The interactive preview uses geometric SVG face primitives instead of the legacy pixel emoticon glyphs. Its baseline face is a pair of rounded-rectangle eyes; keep new face work vector-native and do not replace it with web fonts, canvas text, or raster images. The legacy pixel avatar generator remains owned by `../../packages/avatar` for its package API, while this editor's Copy SVG and Download SVG actions serialize the current interactive SVG so body, pose, face, lighting, shadow, and outline appearance are preserved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026-present One Works contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/__tests__/avatarDefinition.spec.ts
+++ b/__tests__/avatarDefinition.spec.ts
@@ -138,9 +138,57 @@ describe('Avatar editor public definition bridge', () => {
       showShadow: false,
       viewState: DEFAULT_AVATAR_VIEW_STATE
     }).scene)
-    expect(saved.keyframes).toHaveLength(2)
+    expect(saved.keyframes).toHaveLength(3)
     expect(saved.keyframes[0]?.pitch).toBe(DEFAULT_AVATAR_VIEW_STATE.pitch)
     expect(saved.keyframes[1]?.durationMs).toBe(300)
     expect(saved.keyframes[1]?.pitch).toBe(.4)
+    expect(saved.keyframes[2]?.durationMs).toBe(500)
+    expect(saved.keyframes[2]?.pitch).toBe(.4)
+  })
+
+  it('preserves sparse relative view anchors when opening a public clip in the editor', () => {
+    const scene = createAvatarDefinition({
+      animation: null,
+      avatarOutlineStyle: { color: '#000000', opacity: 80, width: 4 },
+      avatarShadowStyle: { color: '#000000', direction: 45, distance: 12, opacity: 24, softness: 16 },
+      backgroundStyle: 'solid',
+      bodyShape: 'sphere',
+      cameraBackground: '#111315',
+      cameraFrame: 'rounded',
+      colorGrade: { brightness: 1, saturation: 1, tintAmount: 0, tintB: 0, tintG: 0, tintR: 0 },
+      entityParts: [],
+      entityPreset: 'custom',
+      exportSize: 256,
+      faceShadowStyle: { direction: 50, distance: 4, opacity: 28, softness: 0 },
+      faceStyle: DEFAULT_AVATAR_FACE_STYLE,
+      frameShadowStyle: { direction: 90, distance: 12, opacity: 22, softness: 24 },
+      glyph: { leftEye: '0', linkEyes: true, mouth: 'w', rightEye: '0' },
+      gridDensity: 100,
+      interactionMode: 'rotate',
+      lightAzimuth: -35,
+      lightDistance: 0,
+      lightElevation: 40,
+      paletteId: 'signal',
+      showAvatarShadow: true,
+      showFrameShadow: true,
+      showLight: false,
+      showOutline: true,
+      showShadow: false,
+      viewState: { ...DEFAULT_AVATAR_VIEW_STATE, yaw: -.3 }
+    }).scene
+    const saved = avatarAnimationClipToSavedAnimation('sparse', {
+      anchor: 'relative',
+      durationMs: 1000,
+      keyframes: [
+        { atMs: 0, patch: { face: { mouthEnabled: false } } },
+        { atMs: 500, patch: { view: { yaw: .6 } } },
+        { atMs: 1000, patch: { view: { yaw: 1 } } }
+      ],
+      playback: 'once'
+    }, scene)
+    expect(saved.lockStartPosition).toBe(true)
+    expect(saved.keyframes[0]?.yaw).toBeCloseTo(-.3)
+    expect(saved.keyframes[1]?.yaw).toBeCloseTo(-.3)
+    expect(saved.keyframes[2]?.yaw).toBeCloseTo(.1)
   })
 })

--- a/__tests__/avatarDefinition.spec.ts
+++ b/__tests__/avatarDefinition.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  avatarDefinitionToSearchParams,
+  createAvatarDefinition,
+  flattenAvatarAnimationLibraries
+} from '../src/avatarDefinition'
+import { createAvatarEntityParts } from '../src/avatarEntityPresets'
+import { DEFAULT_AVATAR_FACE_STYLE } from '../src/avatarGeometry'
+import { DEFAULT_AVATAR_VIEW_STATE } from '../src/InteractiveAvatar'
+import type { AvatarAnimationLibrary } from '@oneworks/avatar-core'
+
+describe('Avatar editor public definition bridge', () => {
+  it('preserves a custom multipart scene in the editor query bridge', () => {
+    const definition = createAvatarDefinition({
+      animation: null,
+      avatarOutlineStyle: { color: '#000000', opacity: 80, width: 4 },
+      avatarShadowStyle: { color: '#000000', direction: 45, distance: 12, opacity: 24, softness: 16 },
+      backgroundStyle: 'solid',
+      bodyShape: 'sphere',
+      cameraBackground: 'transparent',
+      cameraFrame: 'rounded',
+      colorGrade: { brightness: 1, saturation: 1, tintAmount: 0, tintB: 0, tintG: 0, tintR: 0 },
+      entityParts: createAvatarEntityParts('dog'),
+      entityPreset: 'custom',
+      exportSize: 256,
+      faceShadowStyle: { direction: 50, distance: 4, opacity: 28, softness: 0 },
+      faceStyle: DEFAULT_AVATAR_FACE_STYLE,
+      frameShadowStyle: { direction: 90, distance: 12, opacity: 22, softness: 24 },
+      glyph: { leftEye: '0', linkEyes: true, mouth: 'w', rightEye: '0' },
+      gridDensity: 100,
+      interactionMode: 'rotate',
+      lightAzimuth: -35,
+      lightDistance: 0,
+      lightElevation: 40,
+      paletteId: 'white',
+      showAvatarShadow: true,
+      showFrameShadow: true,
+      showLight: false,
+      showOutline: true,
+      showShadow: false,
+      viewState: DEFAULT_AVATAR_VIEW_STATE
+    })
+    const params = avatarDefinitionToSearchParams(definition)
+    expect(params.get('entity')).toBe('custom')
+    expect(params.get('entityParts')).toContain('ear-left')
+    expect(params.get('cameraBg')).toBe('transparent')
+  })
+
+  it('converts external animation groups into editable editor entries', () => {
+    const definition = createAvatarDefinition({
+      animation: null,
+      avatarOutlineStyle: { color: '#000000', opacity: 80, width: 4 },
+      avatarShadowStyle: { color: '#000000', direction: 45, distance: 12, opacity: 24, softness: 16 },
+      backgroundStyle: 'solid',
+      bodyShape: 'sphere',
+      cameraBackground: '#111315',
+      cameraFrame: 'rounded',
+      colorGrade: { brightness: 1, saturation: 1, tintAmount: 0, tintB: 0, tintG: 0, tintR: 0 },
+      entityParts: [],
+      entityPreset: 'custom',
+      exportSize: 256,
+      faceShadowStyle: { direction: 50, distance: 4, opacity: 28, softness: 0 },
+      faceStyle: DEFAULT_AVATAR_FACE_STYLE,
+      frameShadowStyle: { direction: 90, distance: 12, opacity: 22, softness: 24 },
+      glyph: { leftEye: '0', linkEyes: true, mouth: 'w', rightEye: '0' },
+      gridDensity: 100,
+      interactionMode: 'rotate',
+      lightAzimuth: -35,
+      lightDistance: 0,
+      lightElevation: 40,
+      paletteId: 'signal',
+      showAvatarShadow: true,
+      showFrameShadow: true,
+      showLight: false,
+      showOutline: true,
+      showShadow: false,
+      viewState: DEFAULT_AVATAR_VIEW_STATE
+    })
+    const library: AvatarAnimationLibrary = {
+      groups: {
+        support: {
+          clips: {
+            listen: {
+              anchor: 'relative',
+              durationMs: 400,
+              keyframes: [
+                { atMs: 0, patch: { view: { yaw: 0 } } },
+                { atMs: 400, patch: { view: { yaw: .2 } } }
+              ],
+              label: 'Listen',
+              playback: 'loop'
+            }
+          }
+        }
+      },
+      id: 'customer-support'
+    }
+    const [entry] = flattenAvatarAnimationLibraries([library], definition.scene)
+    expect(entry?.animation.name).toBe('Listen')
+    expect(entry?.animation.keyframes).toHaveLength(2)
+    expect(entry?.animation.id).toBe('public:customer-support:support:listen')
+  })
+})

--- a/__tests__/avatarDefinition.spec.ts
+++ b/__tests__/avatarDefinition.spec.ts
@@ -2,17 +2,22 @@ import { describe, expect, it } from 'vitest'
 
 import {
   avatarAnimationClipToSavedAnimation,
+  avatarDefinitionToState,
   avatarDefinitionToSearchParams,
   createAvatarDefinition,
   flattenAvatarAnimationLibraries
 } from '../src/avatarDefinition'
-import { createAvatarEntityParts } from '../src/avatarEntityPresets'
+import {
+  createAvatarEntityParts,
+  deserializeAvatarEntityParts
+} from '../src/avatarEntityPresets'
 import { DEFAULT_AVATAR_FACE_STYLE } from '../src/avatarGeometry'
 import { DEFAULT_AVATAR_VIEW_STATE } from '../src/InteractiveAvatar'
 import type { AvatarAnimationLibrary } from '@oneworks/avatar-core'
 
 describe('Avatar editor public definition bridge', () => {
   it('preserves a custom multipart scene in the editor query bridge', () => {
+    const customParts = createAvatarEntityParts('dog')
     const definition = createAvatarDefinition({
       animation: null,
       avatarOutlineStyle: { color: '#000000', opacity: 80, width: 4 },
@@ -22,12 +27,12 @@ describe('Avatar editor public definition bridge', () => {
       cameraBackground: 'transparent',
       cameraFrame: 'rounded',
       colorGrade: { brightness: 1, saturation: 1, tintAmount: 0, tintB: 0, tintG: 0, tintR: 0 },
-      entityParts: createAvatarEntityParts('dog'),
+      entityParts: customParts,
       entityPreset: 'custom',
       exportSize: 256,
-      faceShadowStyle: { direction: 50, distance: 4, opacity: 28, softness: 0 },
-      faceStyle: DEFAULT_AVATAR_FACE_STYLE,
-      frameShadowStyle: { direction: 90, distance: 12, opacity: 22, softness: 24 },
+      faceShadowStyle: { color: '#123456', direction: 50, distance: 4, opacity: 28, softness: 0 },
+      faceStyle: { ...DEFAULT_AVATAR_FACE_STYLE, leftEyeHeight: 52, rightEyeHeight: 44 },
+      frameShadowStyle: { color: '#654321', direction: 90, distance: 12, opacity: 22, softness: 24 },
       glyph: { leftEye: '0', linkEyes: true, mouth: 'w', rightEye: '0' },
       gridDensity: 100,
       interactionMode: 'rotate',
@@ -46,6 +51,12 @@ describe('Avatar editor public definition bridge', () => {
     expect(params.get('entity')).toBe('custom')
     expect(params.get('entityParts')).toContain('ear-left')
     expect(params.get('cameraBg')).toBe('transparent')
+    expect(params.get('eyeLeftH')).toBe('52')
+    expect(params.get('eyeRightH')).toBe('44')
+    expect(params.get('shadowColor')).toBe('#123456')
+    expect(params.get('frameShadowColor')).toBe('#654321')
+    expect(deserializeAvatarEntityParts(params.get('entityParts'), 'custom')).toMatchObject(customParts)
+    expect(createAvatarDefinition(avatarDefinitionToState(definition), definition)).toEqual(definition)
   })
 
   it('converts external animation groups into editable editor entries', () => {

--- a/__tests__/avatarDefinition.spec.ts
+++ b/__tests__/avatarDefinition.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  avatarAnimationClipToSavedAnimation,
   avatarDefinitionToSearchParams,
   createAvatarDefinition,
   flattenAvatarAnimationLibraries
@@ -100,5 +101,46 @@ describe('Avatar editor public definition bridge', () => {
     expect(entry?.animation.name).toBe('Listen')
     expect(entry?.animation.keyframes).toHaveLength(2)
     expect(entry?.animation.id).toBe('public:customer-support:support:listen')
+  })
+
+  it('preserves a delayed first public keyframe in the editor timeline', () => {
+    const saved = avatarAnimationClipToSavedAnimation('delayed', {
+      anchor: 'absolute',
+      durationMs: 800,
+      keyframes: [{ atMs: 300, easing: 'linear', patch: { view: { pitch: .4 } } }],
+      playback: 'once'
+    }, createAvatarDefinition({
+      animation: null,
+      avatarOutlineStyle: { color: '#000000', opacity: 80, width: 4 },
+      avatarShadowStyle: { color: '#000000', direction: 45, distance: 12, opacity: 24, softness: 16 },
+      backgroundStyle: 'solid',
+      bodyShape: 'sphere',
+      cameraBackground: '#111315',
+      cameraFrame: 'rounded',
+      colorGrade: { brightness: 1, saturation: 1, tintAmount: 0, tintB: 0, tintG: 0, tintR: 0 },
+      entityParts: [],
+      entityPreset: 'custom',
+      exportSize: 256,
+      faceShadowStyle: { direction: 50, distance: 4, opacity: 28, softness: 0 },
+      faceStyle: DEFAULT_AVATAR_FACE_STYLE,
+      frameShadowStyle: { direction: 90, distance: 12, opacity: 22, softness: 24 },
+      glyph: { leftEye: '0', linkEyes: true, mouth: 'w', rightEye: '0' },
+      gridDensity: 100,
+      interactionMode: 'rotate',
+      lightAzimuth: -35,
+      lightDistance: 0,
+      lightElevation: 40,
+      paletteId: 'signal',
+      showAvatarShadow: true,
+      showFrameShadow: true,
+      showLight: false,
+      showOutline: true,
+      showShadow: false,
+      viewState: DEFAULT_AVATAR_VIEW_STATE
+    }).scene)
+    expect(saved.keyframes).toHaveLength(2)
+    expect(saved.keyframes[0]?.pitch).toBe(DEFAULT_AVATAR_VIEW_STATE.pitch)
+    expect(saved.keyframes[1]?.durationMs).toBe(300)
+    expect(saved.keyframes[1]?.pitch).toBe(.4)
   })
 })

--- a/__tests__/avatarDefinition.spec.ts
+++ b/__tests__/avatarDefinition.spec.ts
@@ -84,7 +84,7 @@ describe('Avatar editor public definition bridge', () => {
           clips: {
             listen: {
               anchor: 'relative',
-              durationMs: 400,
+              durationMs: 500,
               keyframes: [
                 { atMs: 0, patch: { view: { yaw: 0 } } },
                 { atMs: 400, patch: { view: { yaw: .2 } } }

--- a/examples/sdk-demo/index.html
+++ b/examples/sdk-demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OneWorks Avatar SDK demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/examples/sdk-demo/main.tsx
+++ b/examples/sdk-demo/main.tsx
@@ -1,0 +1,91 @@
+import { StrictMode, useRef, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import {
+  createDefaultAvatarDefinition
+} from '@oneworks/avatar-core'
+import type {
+  AvatarAnimationLibrary,
+  AvatarDefinition
+} from '@oneworks/avatar-core'
+import {
+  Avatar,
+  AvatarEditor
+} from '@oneworks/avatar-react'
+import type { AvatarHandle } from '@oneworks/avatar-react'
+import '@oneworks/avatar-react/style.css'
+
+import './style.css'
+
+const animations: AvatarAnimationLibrary = {
+  groups: {
+    support: {
+      clips: {
+        acknowledge: {
+          anchor: 'relative',
+          durationMs: 900,
+          keyframes: [
+            { atMs: 0, patch: { view: { pitch: 0, yaw: 0 } } },
+            { atMs: 250, easing: 'ease-in-out', patch: { view: { pitch: .22, yaw: -.08 } } },
+            { atMs: 600, easing: 'ease-out', patch: { view: { pitch: -.06, yaw: .04 } } },
+            { atMs: 900, easing: 'ease-in-out', patch: { view: { pitch: 0, yaw: 0 } } }
+          ],
+          label: 'Acknowledge',
+          playback: 'once'
+        }
+      },
+      defaultClip: 'acknowledge',
+      label: 'Support'
+    }
+  },
+  id: 'sdk-demo',
+  label: 'SDK demo animations'
+}
+
+function Demo() {
+  const avatarRef = useRef<AvatarHandle>(null)
+  const [definition, setDefinition] = useState<AvatarDefinition>(createDefaultAvatarDefinition)
+
+  return (
+    <main className='sdk-demo'>
+      <section className='sdk-demo__preview'>
+        <div>
+          <p className='sdk-demo__eyebrow'>Public SDK fixture</p>
+          <h1>One scene, every adapter</h1>
+          <p>The preview and editor share a versioned definition and custom animation library.</p>
+        </div>
+        <Avatar
+          ref={avatarRef}
+          animationLibraries={[animations]}
+          definition={definition}
+          interactive
+          onDefinitionChange={setDefinition}
+          theme='dark'
+        />
+        <button
+          onClick={() => avatarRef.current?.play({
+            clipId: 'acknowledge',
+            groupId: 'support',
+            libraryId: 'sdk-demo'
+          })}
+          type='button'
+        >
+          Play custom animation
+        </button>
+      </section>
+      <AvatarEditor
+        animationLibraries={[animations]}
+        definition={definition}
+        locale='en'
+        onDefinitionChange={setDefinition}
+        theme='dark'
+      />
+    </main>
+  )
+}
+
+createRoot(document.querySelector('#root')!).render(
+  <StrictMode>
+    <Demo />
+  </StrictMode>
+)

--- a/examples/sdk-demo/style.css
+++ b/examples/sdk-demo/style.css
@@ -1,0 +1,89 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  background: #0f1012;
+  color: #f7f7f4;
+}
+
+body {
+  margin: 0;
+}
+
+.sdk-demo {
+  display: grid;
+  min-height: 100vh;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  background: #0f1012;
+}
+
+.sdk-demo__preview {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px;
+  border-right: 1px solid #2e3034;
+  background: #15171a;
+}
+
+.sdk-demo__preview h1,
+.sdk-demo__preview p {
+  margin: 0;
+}
+
+.sdk-demo__preview h1 {
+  margin-top: 6px;
+  font-size: 30px;
+  line-height: 1.05;
+}
+
+.sdk-demo__preview p:not(.sdk-demo__eyebrow) {
+  margin-top: 12px;
+  color: #aeb2b8;
+  line-height: 1.5;
+}
+
+.sdk-demo__eyebrow {
+  color: #ff6b45;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.sdk-demo__preview .oneworks-avatar {
+  max-width: 296px;
+  margin-inline: auto;
+}
+
+.sdk-demo button {
+  min-height: 44px;
+  border: 0;
+  border-radius: 10px;
+  background: #ff6b45;
+  color: #111315;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.sdk-demo > .oneworks-avatar-editor {
+  height: 100vh;
+  min-height: 640px;
+}
+
+@media (max-width: 880px) {
+  .sdk-demo {
+    grid-template-columns: 1fr;
+  }
+
+  .sdk-demo__preview {
+    border-right: 0;
+    border-bottom: 1px solid #2e3034;
+  }
+
+  .sdk-demo > .oneworks-avatar-editor {
+    height: 760px;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0-alpha.0",
   "packageManager": "pnpm@11.7.0",
   "private": true,
-  "description": "OneWorks pixel-rect avatar previews and SVG assets",
+  "description": "OneWorks geometric 3D Avatar editor, runtime, and framework adapters",
   "repository": {
     "type": "git",
     "url": "https://github.com/oneworks-ai/avatar.git"
@@ -13,24 +13,35 @@
     "build": "pnpm build:app-source",
     "build:app-source": "tsc -p tsconfig.app-source.json --noEmit --pretty false && vite build",
     "build:npm": "tsc -p tsconfig.json --noEmit --pretty false && vite build",
+    "build:sdk": "pnpm --filter './packages/*' build",
     "dev": "vite",
     "preview": "vite preview",
+    "smoke:sdk": "node scripts/smoke-sdk-packages.mjs",
+    "test": "vitest run __tests__/*.spec.ts packages/core/__tests__/*.spec.ts packages/web/__tests__/*.spec.ts",
     "typecheck": "tsc -p tsconfig.app-source.json --noEmit --pretty false",
-    "typecheck:npm": "tsc -p tsconfig.json --noEmit --pretty false"
+    "typecheck:npm": "tsc -p tsconfig.json --noEmit --pretty false",
+    "typecheck:sdk": "pnpm build:sdk && pnpm --filter './packages/*' typecheck"
   },
   "dependencies": {
     "@oneworks/avatar": "beta",
+    "@oneworks/avatar-core": "workspace:*",
     "@oneworks/route-layout": "beta",
     "gifenc": "^1.0.3"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.2",
+    "@vitejs/plugin-vue": "^5.2.4",
+    "jsdom": "^26.1.0",
     "@vitejs/plugin-react": "^5.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sass": "^1.97.2",
     "typescript": "^5.9.3",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "vite-plugin-dts": "^4.5.4",
+    "vitest": "^3.2.4",
+    "vue": "^3.5.21",
+    "vue-tsc": "^2.2.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "vite",
     "preview": "vite preview",
     "smoke:sdk": "node scripts/smoke-sdk-packages.mjs",
-    "test": "vitest run __tests__/*.spec.ts packages/core/__tests__/*.spec.ts packages/web/__tests__/*.spec.ts",
+    "test": "vitest run __tests__/*.spec.ts packages/core/__tests__/*.spec.ts packages/react/__tests__/*.spec.tsx packages/web/__tests__/*.spec.ts",
     "typecheck": "tsc -p tsconfig.app-source.json --noEmit --pretty false",
     "typecheck:npm": "tsc -p tsconfig.json --noEmit --pretty false",
     "typecheck:sdk": "pnpm build:sdk && pnpm --filter './packages/*' typecheck"

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026-present One Works contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,14 @@
+# @oneworks/avatar-core
+
+[English](README.md) | [简体中文](README.zh-Hans.md)
+
+Versioned, framework-neutral definitions and animation helpers for OneWorks 3D Avatar.
+
+```ts
+import { createDefaultAvatarDefinition, serializeAvatarDefinition } from '@oneworks/avatar-core'
+
+const definition = createDefaultAvatarDefinition()
+const json = serializeAvatarDefinition(definition)
+```
+
+See the [Avatar developer guide](https://oneworks.cloud/docs/en/usage/avatar#developer-integration).

--- a/packages/core/README.zh-Hans.md
+++ b/packages/core/README.zh-Hans.md
@@ -1,0 +1,14 @@
+# @oneworks/avatar-core
+
+[English](README.md) | [简体中文](README.zh-Hans.md)
+
+OneWorks 3D Avatar 的版本化、框架无关 definition 与动画工具。
+
+```ts
+import { createDefaultAvatarDefinition, serializeAvatarDefinition } from '@oneworks/avatar-core'
+
+const definition = createDefaultAvatarDefinition()
+const json = serializeAvatarDefinition(definition)
+```
+
+完整说明见 [Avatar 开发者接入指南](https://oneworks.cloud/docs/usage/avatar#开发者接入)。

--- a/packages/core/__tests__/runtime.spec.ts
+++ b/packages/core/__tests__/runtime.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  anchorAvatarAnimationClip,
+  applyAvatarScenePatch,
+  createDefaultAvatarDefinition,
+  mergeAvatarAnimationLibraries,
+  parseAvatarDefinition,
+  resolveAvatarAnimationClip,
+  resolveAvatarAnimationFrame,
+  serializeAvatarDefinition
+} from '../src'
+import type {
+  AvatarAnimationClip,
+  AvatarAnimationLibrary
+} from '../src'
+
+const nod: AvatarAnimationClip = {
+  anchor: 'relative',
+  durationMs: 1000,
+  keyframes: [
+    { atMs: 0, patch: { view: { pitch: 0, yaw: 0 } } },
+    { atMs: 1000, easing: 'linear', patch: { view: { pitch: .4, yaw: .6 } } }
+  ],
+  playback: 'once'
+}
+
+const supportLibrary: AvatarAnimationLibrary = {
+  groups: {
+    attention: {
+      clips: { nod },
+      defaultClip: 'nod'
+    }
+  },
+  id: 'support'
+}
+
+describe('OneWorks Avatar public runtime contract', () => {
+  it('round-trips a versioned definition', () => {
+    const definition = createDefaultAvatarDefinition()
+    expect(parseAvatarDefinition(serializeAvatarDefinition(definition))).toEqual(definition)
+    expect(() => parseAvatarDefinition({ ...definition, version: 2 })).toThrow(TypeError)
+    expect(() => parseAvatarDefinition({
+      ...definition,
+      scene: { ...definition.scene, face: { ...definition.scene.face, width: undefined } }
+    })).toThrow(TypeError)
+    expect(() => parseAvatarDefinition({
+      ...definition,
+      animations: {
+        groups: { broken: { clips: { nope: { durationMs: 'fast' } } } },
+        id: 'broken'
+      }
+    })).toThrow(TypeError)
+  })
+
+  it('resolves custom animation groups with deterministic library precedence', () => {
+    const replacement = {
+      ...supportLibrary,
+      groups: {
+        attention: {
+          clips: { wave: { ...nod, label: 'Wave' } },
+          defaultClip: 'wave'
+        }
+      }
+    }
+    const libraries = mergeAvatarAnimationLibraries([supportLibrary, replacement])
+    expect(libraries).toHaveLength(1)
+    expect(resolveAvatarAnimationClip(libraries, {
+      clipId: 'wave',
+      groupId: 'attention',
+      libraryId: 'support'
+    })?.label).toBe('Wave')
+  })
+
+  it('anchors relative motion to the consumer definition and interpolates it', () => {
+    const definition = applyAvatarScenePatch(createDefaultAvatarDefinition().scene, {
+      view: { pitch: .2, positionX: 12, positionY: -8, yaw: -.3 }
+    })
+    const source = { ...createDefaultAvatarDefinition(), scene: definition }
+    const anchored = anchorAvatarAnimationClip(source, nod)
+    const middle = resolveAvatarAnimationFrame(source, anchored, 500)
+    expect(middle.scene.view.pitch).toBeCloseTo(.4)
+    expect(middle.scene.view.yaw).toBeCloseTo(0)
+    expect(middle.scene.view.positionX).toBe(12)
+    expect(middle.finished).toBe(false)
+    expect(resolveAvatarAnimationFrame(source, anchored, 1000).finished).toBe(true)
+  })
+})

--- a/packages/core/__tests__/runtime.spec.ts
+++ b/packages/core/__tests__/runtime.spec.ts
@@ -47,11 +47,51 @@ describe('OneWorks Avatar public runtime contract', () => {
     })).toThrow(TypeError)
     expect(() => parseAvatarDefinition({
       ...definition,
+      scene: {
+        ...definition.scene,
+        effects: {
+          ...definition.scene.effects,
+          colorGrade: { ...definition.scene.effects.colorGrade, brightness: 2 }
+        }
+      }
+    })).toThrow(TypeError)
+    expect(() => parseAvatarDefinition({
+      ...definition,
       animations: {
         groups: { broken: { clips: { nope: { durationMs: 'fast' } } } },
         id: 'broken'
       }
     })).toThrow(TypeError)
+    expect(() => parseAvatarAnimationClip({
+      anchor: 'absolute',
+      durationMs: 100,
+      keyframes: [{ atMs: 0, patch: { colorGrade: { tintAmount: 1.1 } } }],
+      playback: 'once'
+    })).toThrow(TypeError)
+    expect(() => parseAvatarAnimationClip({
+      anchor: 'absolute',
+      durationMs: 100,
+      keyframes: [{ atMs: 0, patch: { colorGrade: { tintR: 256 } } }],
+      playback: 'once'
+    })).toThrow(TypeError)
+    expect(parseAvatarAnimationClip({
+      anchor: 'absolute',
+      durationMs: 100,
+      keyframes: [{
+        atMs: 0,
+        patch: {
+          colorGrade: {
+            brightness: .35,
+            saturation: 2,
+            tintAmount: 1,
+            tintB: 0,
+            tintG: 255,
+            tintR: 255
+          }
+        }
+      }],
+      playback: 'once'
+    }).keyframes).toHaveLength(1)
     expect(() => parseAvatarDefinition({
       ...definition,
       animations: {

--- a/packages/core/__tests__/runtime.spec.ts
+++ b/packages/core/__tests__/runtime.spec.ts
@@ -51,6 +51,100 @@ describe('OneWorks Avatar public runtime contract', () => {
         id: 'broken'
       }
     })).toThrow(TypeError)
+    expect(() => parseAvatarDefinition({
+      ...definition,
+      animations: {
+        groups: {
+          broken: {
+            clips: {
+              nope: {
+                anchor: 'absolute',
+                durationMs: 100,
+                keyframes: [{ atMs: 101, patch: {} }],
+                playback: 'once'
+              }
+            }
+          }
+        },
+        id: 'broken'
+      }
+    })).toThrow(TypeError)
+    expect(() => parseAvatarDefinition({
+      ...definition,
+      animations: {
+        groups: {
+          broken: {
+            clips: {
+              nope: {
+                anchor: 'absolute',
+                durationMs: 100,
+                keyframes: [{ atMs: 0, patch: { lighting: { enabled: true } } }],
+                playback: 'once'
+              }
+            }
+          }
+        },
+        id: 'broken'
+      }
+    })).toThrow(TypeError)
+    const withFaceAnimation = {
+      ...definition,
+      animations: {
+        groups: {
+          valid: {
+            clips: {
+              expression: {
+                anchor: 'absolute' as const,
+                durationMs: 100,
+                keyframes: [{
+                  atMs: 0,
+                  patch: { face: { eyeShape: 'rounded' as const, noseEnabled: false } }
+                }],
+                playback: 'once' as const
+              }
+            }
+          }
+        },
+        id: 'valid'
+      }
+    }
+    expect(parseAvatarDefinition(serializeAvatarDefinition(withFaceAnimation))).toEqual(withFaceAnimation)
+    expect(() => parseAvatarDefinition({
+      ...definition,
+      animations: {
+        groups: {
+          broken: {
+            clips: {
+              nope: {
+                anchor: 'absolute',
+                durationMs: 100,
+                keyframes: [{ atMs: 0, patch: { face: { width: 'wide' } } }],
+                playback: 'once'
+              }
+            }
+          }
+        },
+        id: 'broken'
+      }
+    })).toThrow(TypeError)
+    expect(() => parseAvatarDefinition({
+      ...definition,
+      animations: {
+        groups: {
+          broken: {
+            clips: {
+              nope: {
+                anchor: 'absolute',
+                durationMs: 100,
+                keyframes: [{ atMs: 0, patch: { view: { roll: 1 } } }],
+                playback: 'once'
+              }
+            }
+          }
+        },
+        id: 'broken'
+      }
+    })).toThrow(TypeError)
   })
 
   it('resolves custom animation groups with deterministic library precedence', () => {
@@ -84,5 +178,42 @@ describe('OneWorks Avatar public runtime contract', () => {
     expect(middle.scene.view.positionX).toBe(12)
     expect(middle.finished).toBe(false)
     expect(resolveAvatarAnimationFrame(source, anchored, 1000).finished).toBe(true)
+  })
+
+  it('anchors each sparse view dimension at its first authored keyframe', () => {
+    const source = createDefaultAvatarDefinition()
+    const definition = {
+      ...source,
+      scene: applyAvatarScenePatch(source.scene, { view: { yaw: -.3 } })
+    }
+    const clip: AvatarAnimationClip = {
+      anchor: 'relative',
+      durationMs: 1000,
+      keyframes: [
+        { atMs: 0, patch: { face: { mouthEnabled: false } } },
+        { atMs: 500, patch: { view: { yaw: .6 } } },
+        { atMs: 1000, patch: { view: { yaw: 1 } } }
+      ],
+      playback: 'once'
+    }
+    const anchored = anchorAvatarAnimationClip(definition, clip)
+    expect(resolveAvatarAnimationFrame(definition, anchored, 500).scene.view.yaw).toBeCloseTo(-.3)
+    expect(resolveAvatarAnimationFrame(definition, anchored, 1000).scene.view.yaw).toBeCloseTo(.1)
+  })
+
+  it('interpolates from the base scene to a delayed first keyframe', () => {
+    const definition = createDefaultAvatarDefinition()
+    const clip: AvatarAnimationClip = {
+      anchor: 'absolute',
+      durationMs: 1000,
+      keyframes: [{ atMs: 500, easing: 'linear', patch: { view: { pitch: .6 } } }],
+      playback: 'once'
+    }
+    expect(resolveAvatarAnimationFrame(definition, clip, 0).scene.view.pitch).toBe(0)
+    expect(resolveAvatarAnimationFrame(definition, clip, 250).scene.view.pitch).toBeCloseTo(.3)
+    expect(resolveAvatarAnimationFrame(definition, clip, 500).scene.view.pitch).toBeCloseTo(.6)
+    const looping = { ...clip, playback: 'loop' as const }
+    expect(resolveAvatarAnimationFrame(definition, looping, 750).scene.view.pitch).toBeCloseTo(.3)
+    expect(resolveAvatarAnimationFrame(definition, looping, 1000).scene.view.pitch).toBe(0)
   })
 })

--- a/packages/core/__tests__/runtime.spec.ts
+++ b/packages/core/__tests__/runtime.spec.ts
@@ -5,6 +5,7 @@ import {
   applyAvatarScenePatch,
   createDefaultAvatarDefinition,
   mergeAvatarAnimationLibraries,
+  parseAvatarAnimationClip,
   parseAvatarDefinition,
   resolveAvatarAnimationClip,
   resolveAvatarAnimationFrame,
@@ -215,5 +216,44 @@ describe('OneWorks Avatar public runtime contract', () => {
     const looping = { ...clip, playback: 'loop' as const }
     expect(resolveAvatarAnimationFrame(definition, looping, 750).scene.view.pitch).toBeCloseTo(.3)
     expect(resolveAvatarAnimationFrame(definition, looping, 1000).scene.view.pitch).toBe(0)
+  })
+
+  it('rejects timeline segments the editor cannot represent losslessly', () => {
+    expect(() => parseAvatarAnimationClip({
+      anchor: 'absolute',
+      durationMs: 50,
+      keyframes: [
+        { atMs: 0, patch: {} },
+        { atMs: 50, patch: { view: { yaw: .1 } } }
+      ],
+      playback: 'once'
+    })).toThrow(TypeError)
+    expect(() => parseAvatarAnimationClip({
+      anchor: 'absolute',
+      durationMs: 9000,
+      keyframes: [
+        { atMs: 0, patch: {} },
+        { atMs: 9000, patch: { view: { yaw: .1 } } }
+      ],
+      playback: 'once'
+    })).toThrow(TypeError)
+    expect(() => parseAvatarAnimationClip({
+      anchor: 'absolute',
+      durationMs: 800,
+      keyframes: [
+        { atMs: 0, patch: {} },
+        { atMs: 800, patch: { view: { yaw: .1 } } }
+      ],
+      playback: 'loop'
+    })).toThrow(TypeError)
+    expect(parseAvatarAnimationClip({
+      anchor: 'absolute',
+      durationMs: 900,
+      keyframes: [
+        { atMs: 0, patch: {} },
+        { atMs: 300, patch: { view: { yaw: .1 } } }
+      ],
+      playback: 'loop'
+    }).durationMs).toBe(900)
   })
 })

--- a/packages/core/__tests__/runtime.spec.ts
+++ b/packages/core/__tests__/runtime.spec.ts
@@ -246,6 +246,12 @@ describe('OneWorks Avatar public runtime contract', () => {
       ],
       playback: 'loop'
     })).toThrow(TypeError)
+    expect(() => parseAvatarAnimationClip({
+      anchor: 'absolute',
+      durationMs: 500,
+      keyframes: [{ atMs: 0, patch: { view: { yaw: .1 } } }],
+      playback: 'loop'
+    })).toThrow(TypeError)
     expect(parseAvatarAnimationClip({
       anchor: 'absolute',
       durationMs: 900,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@oneworks/avatar-core",
+  "version": "0.1.0-alpha.0",
+  "description": "Framework-neutral OneWorks 3D Avatar definitions and animation runtime",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneworks-ai/avatar.git",
+    "directory": "packages/core"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "README.zh-Hans.md"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit --pretty false"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -155,10 +155,8 @@ export interface AvatarScene {
 
 export interface AvatarScenePatch {
   readonly colorGrade?: Partial<AvatarColorGrade>
-  readonly entityParts?: Readonly<Record<string, Partial<AvatarEntityPart>>>
   readonly face?: Partial<AvatarFace>
-  readonly lighting?: Partial<AvatarScene['lighting']>
-  readonly view?: Partial<AvatarView>
+  readonly view?: Partial<Pick<AvatarView, 'pitch' | 'positionX' | 'positionY' | 'yaw'>>
 }
 
 export interface AvatarAnimationKeyframe {
@@ -354,37 +352,54 @@ const isPartialNumberRecord = (value: unknown, keys: readonly string[]) => (
   isRecord(value) && Object.entries(value).every(([key, field]) => keys.includes(key) && isFiniteNumber(field))
 )
 
-const isAvatarScenePatch = (value: unknown): value is AvatarScenePatch => {
+const isPartialAvatarFace = (value: unknown) => {
   if (!isRecord(value)) return false
+  const numberKeys = [
+    'eyeRoundness', 'gap', 'height', 'leftEyeHeight', 'leftEyeRotation', 'mouthCurve',
+    'mouthHeight', 'mouthRotation', 'mouthWidth', 'mouthY', 'noseHeight', 'noseRotation',
+    'noseWidth', 'noseY', 'rotation', 'rightEyeHeight', 'rightEyeRotation', 'width'
+  ]
+  const booleanKeys = ['mouthEnabled', 'noseEnabled']
+  return Object.entries(value).every(([key, field]) => {
+    if (numberKeys.includes(key)) return isFiniteNumber(field)
+    if (booleanKeys.includes(key)) return isBoolean(field)
+    if (key === 'eyeShape') return isOneOf(field, ['ellipse', 'rounded'])
+    if (key === 'mouthShape') {
+      return isOneOf(field, ['curve', 'ellipse', 'rounded', 'rounded-triangle'])
+    }
+    if (key === 'noseShape') return isOneOf(field, ['ellipse', 'inverted-triangle', 'rounded'])
+    return false
+  })
+}
+
+const isAvatarScenePatch = (value: unknown): value is AvatarScenePatch => {
+  if (!isRecord(value) || Object.keys(value).some(key => !['colorGrade', 'face', 'view'].includes(key))) {
+    return false
+  }
   if (value.colorGrade != null && !isPartialNumberRecord(value.colorGrade, [
     'brightness', 'saturation', 'tintAmount', 'tintB', 'tintG', 'tintR'
   ])) return false
   if (value.view != null && !isPartialNumberRecord(value.view, [
-    'pitch', 'positionX', 'positionY', 'roll', 'scale', 'yaw'
+    'pitch', 'positionX', 'positionY', 'yaw'
   ])) return false
-  if (value.lighting != null && (!isRecord(value.lighting) || Object.entries(value.lighting).some(
-    ([key, field]) => key === 'enabled'
-      ? !isBoolean(field)
-      : !['azimuth', 'distance', 'elevation', 'gridDensity'].includes(key) || !isFiniteNumber(field)
-  ))) return false
-  if (value.face != null && !isRecord(value.face)) return false
-  if (value.entityParts != null && (!isRecord(value.entityParts) || Object.values(value.entityParts).some(
-    part => !isRecord(part)
-  ))) return false
+  if (value.face != null && !isPartialAvatarFace(value.face)) return false
   return true
 }
 
-const isAvatarAnimationClip = (value: unknown): value is AvatarAnimationClip => (
-  isRecord(value) && isOneOf(value.anchor, ['absolute', 'relative']) &&
-  isFiniteNumber(value.durationMs) && value.durationMs > 0 && isOptionalString(value.label) &&
-  isOneOf(value.playback, ['loop', 'once']) && Array.isArray(value.keyframes) &&
-  value.keyframes.every(keyframe => (
+const isAvatarAnimationClip = (value: unknown): value is AvatarAnimationClip => {
+  if (!isRecord(value) || !isOneOf(value.anchor, ['absolute', 'relative']) ||
+    !isFiniteNumber(value.durationMs) || value.durationMs <= 0 || !isOptionalString(value.label) ||
+    !isOneOf(value.playback, ['loop', 'once']) || !Array.isArray(value.keyframes) ||
+    value.keyframes.length === 0) return false
+  const durationMs = value.durationMs
+  return value.keyframes.every(keyframe => (
     isRecord(keyframe) && isFiniteNumber(keyframe.atMs) && keyframe.atMs >= 0 &&
+    keyframe.atMs <= durationMs &&
     (keyframe.easing == null || isOneOf(keyframe.easing, [
       'ease-in', 'ease-in-out', 'ease-out', 'linear'
     ])) && isAvatarScenePatch(keyframe.patch)
   ))
-)
+}
 
 const isAvatarAnimationLibrary = (value: unknown): value is AvatarAnimationLibrary => (
   isRecord(value) && isString(value.id) && isOptionalString(value.label) && isRecord(value.groups) &&
@@ -461,14 +476,13 @@ export const anchorAvatarAnimationClip = (
   clip: AvatarAnimationClip
 ): AvatarAnimationClip => {
   if (clip.anchor === 'absolute' || clip.keyframes.length === 0) return clip
-  const first = [...clip.keyframes].sort((a, b) => a.atMs - b.atMs)[0]!
-  const firstScene = applyAvatarScenePatch(definition.scene, first.patch)
-  const delta = {
-    pitch: definition.scene.view.pitch - firstScene.view.pitch,
-    positionX: definition.scene.view.positionX - firstScene.view.positionX,
-    positionY: definition.scene.view.positionY - firstScene.view.positionY,
-    yaw: definition.scene.view.yaw - firstScene.view.yaw
-  }
+  const ordered = [...clip.keyframes].sort((a, b) => a.atMs - b.atMs)
+  const viewKeys = ['pitch', 'positionX', 'positionY', 'yaw'] as const
+  const delta = Object.fromEntries(viewKeys.map(key => {
+    const first = ordered.find(frame => frame.patch.view?.[key] != null)
+    const authored = first?.patch.view?.[key]
+    return [key, authored == null ? 0 : definition.scene.view[key] - authored]
+  })) as Record<(typeof viewKeys)[number], number>
   return {
     ...clip,
     anchor: 'absolute',
@@ -476,17 +490,13 @@ export const anchorAvatarAnimationClip = (
       ...frame,
       patch: {
         ...frame.patch,
-        view: {
-          ...frame.patch.view,
-          ...(frame.patch.view?.pitch == null ? {} : { pitch: frame.patch.view.pitch + delta.pitch }),
-          ...(frame.patch.view?.positionX == null
-            ? {}
-            : { positionX: frame.patch.view.positionX + delta.positionX }),
-          ...(frame.patch.view?.positionY == null
-            ? {}
-            : { positionY: frame.patch.view.positionY + delta.positionY }),
-          ...(frame.patch.view?.yaw == null ? {} : { yaw: frame.patch.view.yaw + delta.yaw })
-        }
+        ...(frame.patch.view == null
+          ? {}
+          : {
+              view: Object.fromEntries(Object.entries(frame.patch.view).map(([key, value]) => (
+                [key, value + delta[key as keyof typeof delta]]
+              )))
+            })
       }
     }))
   }
@@ -509,14 +519,7 @@ export const applyAvatarScenePatch = (scene: AvatarScene, patch: AvatarScenePatc
     ...scene.effects,
     colorGrade: { ...scene.effects.colorGrade, ...patch.colorGrade }
   },
-  entity: patch.entityParts == null
-    ? scene.entity
-    : {
-        ...scene.entity,
-        parts: scene.entity.parts.map(part => ({ ...part, ...patch.entityParts?.[part.id] }))
-      },
   face: { ...scene.face, ...patch.face },
-  lighting: { ...scene.lighting, ...patch.lighting },
   view: { ...scene.view, ...patch.view }
 })
 
@@ -542,15 +545,7 @@ const interpolateScene = (from: AvatarScene, to: AvatarScene, progress: number):
     ...from.effects,
     colorGrade: interpolateRecord(from.effects.colorGrade, to.effects.colorGrade, progress)
   },
-  entity: {
-    ...from.entity,
-    parts: from.entity.parts.map(part => {
-      const target = to.entity.parts.find(candidate => candidate.id === part.id)
-      return target == null ? part : interpolateRecord(part, target, progress)
-    })
-  },
   face: interpolateRecord(from.face, to.face, progress),
-  lighting: interpolateRecord(from.lighting, to.lighting, progress),
   view: interpolateRecord(from.view, to.view, progress)
 })
 
@@ -559,10 +554,13 @@ export const resolveAvatarAnimationFrame = (
   clip: AvatarAnimationClip,
   elapsedMs: number
 ): ResolvedAvatarAnimationFrame => {
-  const ordered = [...clip.keyframes].sort((a, b) => a.atMs - b.atMs)
-  if (ordered.length === 0 || clip.durationMs <= 0) {
+  const authored = [...clip.keyframes].sort((a, b) => a.atMs - b.atMs)
+  if (authored.length === 0 || clip.durationMs <= 0) {
     return { elapsedMs: 0, finished: true, progress: 1, scene: definition.scene }
   }
+  const ordered: readonly AvatarAnimationKeyframe[] = authored[0]!.atMs > 0
+    ? [{ atMs: 0, easing: authored[0]!.easing, patch: {} }, ...authored]
+    : authored
   const requested = Math.max(elapsedMs, 0)
   const finished = clip.playback === 'once' && requested >= clip.durationMs
   const timeline = clip.playback === 'loop'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,14 @@ export const AVATAR_DEFINITION_SCHEMA = 'oneworks.avatar' as const
 export const AVATAR_DEFINITION_VERSION = 1 as const
 export const AVATAR_ANIMATION_MIN_SEGMENT_MS = 100
 export const AVATAR_ANIMATION_MAX_SEGMENT_MS = 8000
+export const AVATAR_COLOR_GRADE_RANGES = {
+  brightness: { max: 1.8, min: .35 },
+  saturation: { max: 2, min: 0 },
+  tintAmount: { max: 1, min: 0 },
+  tintB: { max: 255, min: 0 },
+  tintG: { max: 255, min: 0 },
+  tintR: { max: 255, min: 0 }
+} as const
 
 export type AvatarBackgroundStyle = 'gradient' | 'solid'
 export type AvatarBodyShape =
@@ -293,10 +301,20 @@ const isOneOf = <T extends string>(value: unknown, options: readonly T[]): value
   isString(value) && options.includes(value as T)
 )
 
+const isAvatarColorGradeField = (key: string, value: unknown) => {
+  const range = AVATAR_COLOR_GRADE_RANGES[key as keyof AvatarColorGrade]
+  return range != null && isFiniteNumber(value) && value >= range.min && value <= range.max
+}
+
+const isPartialAvatarColorGrade = (value: unknown) => (
+  isRecord(value) && Object.entries(value).every(([key, field]) => (
+    isAvatarColorGradeField(key, field)
+  ))
+)
+
 const isAvatarColorGrade = (value: unknown): value is AvatarColorGrade => (
-  isRecord(value) && isFiniteNumber(value.brightness) && isFiniteNumber(value.saturation) &&
-  isFiniteNumber(value.tintAmount) && isFiniteNumber(value.tintB) &&
-  isFiniteNumber(value.tintG) && isFiniteNumber(value.tintR)
+  isRecord(value) && Object.keys(value).length === Object.keys(AVATAR_COLOR_GRADE_RANGES).length &&
+  Object.entries(value).every(([key, field]) => isAvatarColorGradeField(key, field))
 )
 
 const isAvatarShadow = (value: unknown): value is AvatarShadow => (
@@ -378,9 +396,7 @@ const isAvatarScenePatch = (value: unknown): value is AvatarScenePatch => {
   if (!isRecord(value) || Object.keys(value).some(key => !['colorGrade', 'face', 'view'].includes(key))) {
     return false
   }
-  if (value.colorGrade != null && !isPartialNumberRecord(value.colorGrade, [
-    'brightness', 'saturation', 'tintAmount', 'tintB', 'tintG', 'tintR'
-  ])) return false
+  if (value.colorGrade != null && !isPartialAvatarColorGrade(value.colorGrade)) return false
   if (value.view != null && !isPartialNumberRecord(value.view, [
     'pitch', 'positionX', 'positionY', 'yaw'
   ])) return false

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,600 @@
+export const AVATAR_DEFINITION_SCHEMA = 'oneworks.avatar' as const
+export const AVATAR_DEFINITION_VERSION = 1 as const
+
+export type AvatarBackgroundStyle = 'gradient' | 'solid'
+export type AvatarBodyShape =
+  | 'capsule'
+  | 'cone'
+  | 'diamond'
+  | 'ellipse'
+  | 'frustum'
+  | 'half-cone'
+  | 'rounded'
+  | 'square'
+  | 'sphere'
+  | 'teardrop'
+  | 'trapezoid'
+export type AvatarCameraFrame = 'circle' | 'rounded' | 'square'
+export type AvatarEntityPreset = 'bear' | 'cat' | 'cloud' | 'custom' | 'dog' | 'rabbit' | 'sun'
+export type AvatarEyeShape = 'ellipse' | 'rounded'
+export type AvatarInteractionMode = 'move' | 'rotate'
+export type AvatarMouthShape = 'curve' | 'ellipse' | 'rounded' | 'rounded-triangle'
+export type AvatarNoseShape = 'ellipse' | 'inverted-triangle' | 'rounded'
+export type AvatarPlaybackMode = 'loop' | 'once'
+export type AvatarAnimationAnchor = 'absolute' | 'relative'
+export type AvatarAnimationEasing = 'ease-in' | 'ease-in-out' | 'ease-out' | 'linear'
+
+export interface AvatarColorGrade {
+  readonly brightness: number
+  readonly saturation: number
+  readonly tintAmount: number
+  readonly tintB: number
+  readonly tintG: number
+  readonly tintR: number
+}
+
+export interface AvatarView {
+  readonly pitch: number
+  readonly positionX: number
+  readonly positionY: number
+  readonly roll: number
+  readonly scale: number
+  readonly yaw: number
+}
+
+export interface AvatarFace {
+  readonly eyeRoundness: number
+  readonly eyeShape: AvatarEyeShape
+  readonly gap: number
+  readonly height: number
+  readonly leftEyeHeight?: number
+  readonly leftEyeRotation: number
+  readonly mouthCurve: number
+  readonly mouthEnabled: boolean
+  readonly mouthHeight: number
+  readonly mouthRotation: number
+  readonly mouthShape: AvatarMouthShape
+  readonly mouthWidth: number
+  readonly mouthY: number
+  readonly noseEnabled: boolean
+  readonly noseHeight: number
+  readonly noseRotation: number
+  readonly noseShape: AvatarNoseShape
+  readonly noseWidth: number
+  readonly noseY: number
+  readonly rotation: number
+  readonly rightEyeHeight?: number
+  readonly rightEyeRotation: number
+  readonly width: number
+}
+
+export interface AvatarEntityPart {
+  readonly baseColor: string
+  readonly cutAngle?: number
+  readonly face: boolean
+  readonly foregroundColor: string
+  readonly highlightColor: string
+  readonly hollow?: boolean
+  readonly id: string
+  readonly label: string
+  readonly occlusionAmount?: number
+  readonly occludedByFace?: boolean
+  readonly occlusionPole?: 'bottom' | 'top'
+  readonly rotationX?: number
+  readonly rotationY?: number
+  readonly rotationZ?: number
+  readonly roundness?: number
+  readonly scaleX: number
+  readonly scaleY: number
+  readonly scaleZ?: number
+  readonly shadowColor: string
+  readonly shape: AvatarBodyShape
+  readonly topScale?: number
+  readonly x: number
+  readonly y: number
+  readonly z: number
+}
+
+export interface AvatarShadow {
+  readonly color?: string
+  readonly direction: number
+  readonly distance: number
+  readonly opacity: number
+  readonly softness: number
+}
+
+export interface AvatarOutline {
+  readonly color: string
+  readonly opacity: number
+  readonly width: number
+}
+
+export interface AvatarScene {
+  readonly appearance: {
+    readonly backgroundStyle: AvatarBackgroundStyle
+    readonly bodyShape: AvatarBodyShape
+    readonly paletteId: string
+  }
+  readonly camera: {
+    readonly background: string | 'transparent'
+    readonly frame: AvatarCameraFrame
+    readonly frameShadow: AvatarShadow
+    readonly showFrameShadow: boolean
+    readonly size: 128 | 256 | 512
+  }
+  readonly effects: {
+    readonly avatarShadow: AvatarShadow
+    readonly colorGrade: AvatarColorGrade
+    readonly faceShadow: AvatarShadow
+    readonly outline: AvatarOutline
+    readonly showAvatarShadow: boolean
+    readonly showFaceShadow: boolean
+    readonly showOutline: boolean
+  }
+  readonly entity: {
+    readonly parts: readonly AvatarEntityPart[]
+    readonly preset: AvatarEntityPreset
+  }
+  readonly face: AvatarFace
+  readonly glyph: {
+    readonly leftEye: string
+    readonly linkEyes: boolean
+    readonly mouth: string
+    readonly rightEye: string
+  }
+  readonly interactionMode: AvatarInteractionMode
+  readonly lighting: {
+    readonly azimuth: number
+    readonly distance: number
+    readonly elevation: number
+    readonly gridDensity: number
+    readonly enabled: boolean
+  }
+  readonly view: AvatarView
+}
+
+export interface AvatarScenePatch {
+  readonly colorGrade?: Partial<AvatarColorGrade>
+  readonly entityParts?: Readonly<Record<string, Partial<AvatarEntityPart>>>
+  readonly face?: Partial<AvatarFace>
+  readonly lighting?: Partial<AvatarScene['lighting']>
+  readonly view?: Partial<AvatarView>
+}
+
+export interface AvatarAnimationKeyframe {
+  readonly atMs: number
+  readonly easing?: AvatarAnimationEasing
+  readonly patch: AvatarScenePatch
+}
+
+export interface AvatarAnimationClip {
+  readonly anchor: AvatarAnimationAnchor
+  readonly durationMs: number
+  readonly keyframes: readonly AvatarAnimationKeyframe[]
+  readonly label?: string
+  readonly playback: AvatarPlaybackMode
+}
+
+export interface AvatarAnimationGroup {
+  readonly clips: Readonly<Record<string, AvatarAnimationClip>>
+  readonly defaultClip?: string
+  readonly label?: string
+}
+
+export interface AvatarAnimationLibrary {
+  readonly groups: Readonly<Record<string, AvatarAnimationGroup>>
+  readonly id: string
+  readonly label?: string
+}
+
+export interface AvatarAnimationRef {
+  readonly clipId: string
+  readonly groupId: string
+  readonly libraryId: string
+}
+
+export interface AvatarDefinitionV1 {
+  readonly animations?: AvatarAnimationLibrary
+  readonly metadata?: {
+    readonly createdAt?: string
+    readonly id?: string
+    readonly name?: string
+    readonly updatedAt?: string
+  }
+  readonly scene: AvatarScene
+  readonly schema: typeof AVATAR_DEFINITION_SCHEMA
+  readonly version: typeof AVATAR_DEFINITION_VERSION
+}
+
+export type AvatarDefinition = AvatarDefinitionV1
+
+export interface ResolvedAvatarAnimationFrame {
+  readonly elapsedMs: number
+  readonly finished: boolean
+  readonly progress: number
+  readonly scene: AvatarScene
+}
+
+export const DEFAULT_AVATAR_COLOR_GRADE: AvatarColorGrade = {
+  brightness: 1,
+  saturation: 1,
+  tintAmount: 0,
+  tintB: 0,
+  tintG: 0,
+  tintR: 0
+}
+
+export const DEFAULT_AVATAR_FACE: AvatarFace = {
+  eyeRoundness: 100,
+  eyeShape: 'rounded',
+  gap: 40,
+  height: 64,
+  leftEyeRotation: 0,
+  mouthCurve: 45,
+  mouthEnabled: false,
+  mouthHeight: 12,
+  mouthRotation: 0,
+  mouthShape: 'curve',
+  mouthWidth: 52,
+  mouthY: 52,
+  noseEnabled: false,
+  noseHeight: 18,
+  noseRotation: 0,
+  noseShape: 'inverted-triangle',
+  noseWidth: 10,
+  noseY: 22,
+  rotation: 0,
+  rightEyeRotation: 0,
+  width: 28
+}
+
+export const createDefaultAvatarDefinition = (): AvatarDefinition => ({
+  scene: {
+    appearance: { backgroundStyle: 'solid', bodyShape: 'sphere', paletteId: 'signal' },
+    camera: {
+      background: '#111315',
+      frame: 'rounded',
+      frameShadow: { direction: 90, distance: 12, opacity: 22, softness: 24 },
+      showFrameShadow: true,
+      size: 256
+    },
+    effects: {
+      avatarShadow: { color: '#000000', direction: 45, distance: 12, opacity: 24, softness: 16 },
+      colorGrade: DEFAULT_AVATAR_COLOR_GRADE,
+      faceShadow: { direction: 50, distance: 4, opacity: 28, softness: 0 },
+      outline: { color: '#ffffff', opacity: 80, width: 4 },
+      showAvatarShadow: true,
+      showFaceShadow: false,
+      showOutline: true
+    },
+    entity: { parts: [], preset: 'custom' },
+    face: DEFAULT_AVATAR_FACE,
+    glyph: { leftEye: '0', linkEyes: true, mouth: 'w', rightEye: '0' },
+    interactionMode: 'rotate',
+    lighting: { azimuth: -35, distance: 0, elevation: 40, enabled: false, gridDensity: 100 },
+    view: { pitch: 0, positionX: 0, positionY: 0, roll: 0, scale: 1.28, yaw: 0 }
+  },
+  schema: AVATAR_DEFINITION_SCHEMA,
+  version: AVATAR_DEFINITION_VERSION
+})
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  typeof value === 'object' && value != null && !Array.isArray(value)
+)
+
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean'
+const isFiniteNumber = (value: unknown): value is number => (
+  typeof value === 'number' && Number.isFinite(value)
+)
+const isString = (value: unknown): value is string => typeof value === 'string'
+const isOptionalNumber = (value: unknown) => value == null || isFiniteNumber(value)
+const isOptionalString = (value: unknown) => value == null || isString(value)
+const isOneOf = <T extends string>(value: unknown, options: readonly T[]): value is T => (
+  isString(value) && options.includes(value as T)
+)
+
+const isAvatarColorGrade = (value: unknown): value is AvatarColorGrade => (
+  isRecord(value) && isFiniteNumber(value.brightness) && isFiniteNumber(value.saturation) &&
+  isFiniteNumber(value.tintAmount) && isFiniteNumber(value.tintB) &&
+  isFiniteNumber(value.tintG) && isFiniteNumber(value.tintR)
+)
+
+const isAvatarShadow = (value: unknown): value is AvatarShadow => (
+  isRecord(value) && isOptionalString(value.color) && isFiniteNumber(value.direction) &&
+  isFiniteNumber(value.distance) && isFiniteNumber(value.opacity) && isFiniteNumber(value.softness)
+)
+
+const isAvatarOutline = (value: unknown): value is AvatarOutline => (
+  isRecord(value) && isString(value.color) && isFiniteNumber(value.opacity) &&
+  isFiniteNumber(value.width)
+)
+
+const isAvatarView = (value: unknown): value is AvatarView => (
+  isRecord(value) && isFiniteNumber(value.pitch) && isFiniteNumber(value.positionX) &&
+  isFiniteNumber(value.positionY) && isFiniteNumber(value.roll) && isFiniteNumber(value.scale) &&
+  isFiniteNumber(value.yaw)
+)
+
+const isAvatarFace = (value: unknown): value is AvatarFace => (
+  isRecord(value) && isFiniteNumber(value.eyeRoundness) &&
+  isOneOf(value.eyeShape, ['ellipse', 'rounded']) && isFiniteNumber(value.gap) &&
+  isFiniteNumber(value.height) && isOptionalNumber(value.leftEyeHeight) &&
+  isFiniteNumber(value.leftEyeRotation) && isFiniteNumber(value.mouthCurve) &&
+  isBoolean(value.mouthEnabled) && isFiniteNumber(value.mouthHeight) &&
+  isFiniteNumber(value.mouthRotation) &&
+  isOneOf(value.mouthShape, ['curve', 'ellipse', 'rounded', 'rounded-triangle']) &&
+  isFiniteNumber(value.mouthWidth) && isFiniteNumber(value.mouthY) &&
+  isBoolean(value.noseEnabled) && isFiniteNumber(value.noseHeight) &&
+  isFiniteNumber(value.noseRotation) &&
+  isOneOf(value.noseShape, ['ellipse', 'inverted-triangle', 'rounded']) &&
+  isFiniteNumber(value.noseWidth) && isFiniteNumber(value.noseY) &&
+  isFiniteNumber(value.rotation) && isOptionalNumber(value.rightEyeHeight) &&
+  isFiniteNumber(value.rightEyeRotation) && isFiniteNumber(value.width)
+)
+
+const isAvatarEntityPart = (value: unknown): value is AvatarEntityPart => (
+  isRecord(value) && isString(value.baseColor) && isOptionalNumber(value.cutAngle) &&
+  isBoolean(value.face) && isString(value.foregroundColor) && isString(value.highlightColor) &&
+  (value.hollow == null || isBoolean(value.hollow)) && isString(value.id) && isString(value.label) &&
+  isOptionalNumber(value.occlusionAmount) &&
+  (value.occludedByFace == null || isBoolean(value.occludedByFace)) &&
+  (value.occlusionPole == null || isOneOf(value.occlusionPole, ['bottom', 'top'])) &&
+  isOptionalNumber(value.rotationX) && isOptionalNumber(value.rotationY) &&
+  isOptionalNumber(value.rotationZ) && isOptionalNumber(value.roundness) &&
+  isFiniteNumber(value.scaleX) && isFiniteNumber(value.scaleY) &&
+  isOptionalNumber(value.scaleZ) && isString(value.shadowColor) &&
+  isOneOf(value.shape, [
+    'capsule', 'cone', 'diamond', 'ellipse', 'frustum', 'half-cone', 'rounded', 'square',
+    'sphere', 'teardrop', 'trapezoid'
+  ]) && isOptionalNumber(value.topScale) && isFiniteNumber(value.x) &&
+  isFiniteNumber(value.y) && isFiniteNumber(value.z)
+)
+
+const isPartialNumberRecord = (value: unknown, keys: readonly string[]) => (
+  isRecord(value) && Object.entries(value).every(([key, field]) => keys.includes(key) && isFiniteNumber(field))
+)
+
+const isAvatarScenePatch = (value: unknown): value is AvatarScenePatch => {
+  if (!isRecord(value)) return false
+  if (value.colorGrade != null && !isPartialNumberRecord(value.colorGrade, [
+    'brightness', 'saturation', 'tintAmount', 'tintB', 'tintG', 'tintR'
+  ])) return false
+  if (value.view != null && !isPartialNumberRecord(value.view, [
+    'pitch', 'positionX', 'positionY', 'roll', 'scale', 'yaw'
+  ])) return false
+  if (value.lighting != null && (!isRecord(value.lighting) || Object.entries(value.lighting).some(
+    ([key, field]) => key === 'enabled'
+      ? !isBoolean(field)
+      : !['azimuth', 'distance', 'elevation', 'gridDensity'].includes(key) || !isFiniteNumber(field)
+  ))) return false
+  if (value.face != null && !isRecord(value.face)) return false
+  if (value.entityParts != null && (!isRecord(value.entityParts) || Object.values(value.entityParts).some(
+    part => !isRecord(part)
+  ))) return false
+  return true
+}
+
+const isAvatarAnimationClip = (value: unknown): value is AvatarAnimationClip => (
+  isRecord(value) && isOneOf(value.anchor, ['absolute', 'relative']) &&
+  isFiniteNumber(value.durationMs) && value.durationMs > 0 && isOptionalString(value.label) &&
+  isOneOf(value.playback, ['loop', 'once']) && Array.isArray(value.keyframes) &&
+  value.keyframes.every(keyframe => (
+    isRecord(keyframe) && isFiniteNumber(keyframe.atMs) && keyframe.atMs >= 0 &&
+    (keyframe.easing == null || isOneOf(keyframe.easing, [
+      'ease-in', 'ease-in-out', 'ease-out', 'linear'
+    ])) && isAvatarScenePatch(keyframe.patch)
+  ))
+)
+
+const isAvatarAnimationLibrary = (value: unknown): value is AvatarAnimationLibrary => (
+  isRecord(value) && isString(value.id) && isOptionalString(value.label) && isRecord(value.groups) &&
+  Object.values(value.groups).every(group => (
+    isRecord(group) && isOptionalString(group.defaultClip) && isOptionalString(group.label) &&
+    isRecord(group.clips) && Object.values(group.clips).every(isAvatarAnimationClip)
+  ))
+)
+
+export const isAvatarDefinition = (value: unknown): value is AvatarDefinition => {
+  if (!isRecord(value) || value.schema !== AVATAR_DEFINITION_SCHEMA || value.version !== 1) return false
+  if (value.animations != null && !isAvatarAnimationLibrary(value.animations)) return false
+  if (value.metadata != null && (!isRecord(value.metadata) ||
+    !isOptionalString(value.metadata.createdAt) || !isOptionalString(value.metadata.id) ||
+    !isOptionalString(value.metadata.name) || !isOptionalString(value.metadata.updatedAt))) return false
+  if (!isRecord(value.scene)) return false
+  const scene = value.scene
+  return isRecord(scene.appearance) &&
+    isOneOf(scene.appearance.backgroundStyle, ['gradient', 'solid']) &&
+    isOneOf(scene.appearance.bodyShape, [
+      'capsule', 'cone', 'diamond', 'ellipse', 'frustum', 'half-cone', 'rounded', 'square',
+      'sphere', 'teardrop', 'trapezoid'
+    ]) && isString(scene.appearance.paletteId) &&
+    isRecord(scene.camera) && isString(scene.camera.background) &&
+    isOneOf(scene.camera.frame, ['circle', 'rounded', 'square']) &&
+    isAvatarShadow(scene.camera.frameShadow) && isBoolean(scene.camera.showFrameShadow) &&
+    [128, 256, 512].includes(scene.camera.size as number) &&
+    isRecord(scene.effects) && isAvatarShadow(scene.effects.avatarShadow) &&
+    isAvatarColorGrade(scene.effects.colorGrade) && isAvatarShadow(scene.effects.faceShadow) &&
+    isAvatarOutline(scene.effects.outline) && isBoolean(scene.effects.showAvatarShadow) &&
+    isBoolean(scene.effects.showFaceShadow) && isBoolean(scene.effects.showOutline) &&
+    isRecord(scene.entity) && Array.isArray(scene.entity.parts) &&
+    scene.entity.parts.every(isAvatarEntityPart) &&
+    isOneOf(scene.entity.preset, ['bear', 'cat', 'cloud', 'custom', 'dog', 'rabbit', 'sun']) &&
+    isAvatarFace(scene.face) && isRecord(scene.glyph) && isString(scene.glyph.leftEye) &&
+    isBoolean(scene.glyph.linkEyes) && isString(scene.glyph.mouth) &&
+    isString(scene.glyph.rightEye) && isOneOf(scene.interactionMode, ['move', 'rotate']) &&
+    isRecord(scene.lighting) && isFiniteNumber(scene.lighting.azimuth) &&
+    isFiniteNumber(scene.lighting.distance) && isFiniteNumber(scene.lighting.elevation) &&
+    isBoolean(scene.lighting.enabled) && isFiniteNumber(scene.lighting.gridDensity) &&
+    isAvatarView(scene.view)
+}
+
+export const parseAvatarDefinition = (input: unknown): AvatarDefinition => {
+  const value = typeof input === 'string' ? JSON.parse(input) : input
+  if (!isAvatarDefinition(value)) throw new TypeError('Invalid OneWorks Avatar definition')
+  return structuredClone(value)
+}
+
+export const serializeAvatarDefinition = (definition: AvatarDefinition) => {
+  if (!isAvatarDefinition(definition)) throw new TypeError('Invalid OneWorks Avatar definition')
+  return `${JSON.stringify(definition, null, 2)}\n`
+}
+
+export const mergeAvatarAnimationLibraries = (
+  libraries: readonly AvatarAnimationLibrary[]
+): readonly AvatarAnimationLibrary[] => {
+  const merged = new Map<string, AvatarAnimationLibrary>()
+  libraries.forEach(library => merged.set(library.id, library))
+  return [...merged.values()]
+}
+
+export const resolveAvatarAnimationClip = (
+  libraries: readonly AvatarAnimationLibrary[],
+  reference: AvatarAnimationRef
+): AvatarAnimationClip | null => (
+  libraries.find(library => library.id === reference.libraryId)
+    ?.groups[reference.groupId]
+    ?.clips[reference.clipId] ?? null
+)
+
+export const anchorAvatarAnimationClip = (
+  definition: AvatarDefinition,
+  clip: AvatarAnimationClip
+): AvatarAnimationClip => {
+  if (clip.anchor === 'absolute' || clip.keyframes.length === 0) return clip
+  const first = [...clip.keyframes].sort((a, b) => a.atMs - b.atMs)[0]!
+  const firstScene = applyAvatarScenePatch(definition.scene, first.patch)
+  const delta = {
+    pitch: definition.scene.view.pitch - firstScene.view.pitch,
+    positionX: definition.scene.view.positionX - firstScene.view.positionX,
+    positionY: definition.scene.view.positionY - firstScene.view.positionY,
+    yaw: definition.scene.view.yaw - firstScene.view.yaw
+  }
+  return {
+    ...clip,
+    anchor: 'absolute',
+    keyframes: clip.keyframes.map(frame => ({
+      ...frame,
+      patch: {
+        ...frame.patch,
+        view: {
+          ...frame.patch.view,
+          ...(frame.patch.view?.pitch == null ? {} : { pitch: frame.patch.view.pitch + delta.pitch }),
+          ...(frame.patch.view?.positionX == null
+            ? {}
+            : { positionX: frame.patch.view.positionX + delta.positionX }),
+          ...(frame.patch.view?.positionY == null
+            ? {}
+            : { positionY: frame.patch.view.positionY + delta.positionY }),
+          ...(frame.patch.view?.yaw == null ? {} : { yaw: frame.patch.view.yaw + delta.yaw })
+        }
+      }
+    }))
+  }
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
+const interpolate = (from: number, to: number, progress: number) => from + (to - from) * progress
+
+export const easeAvatarAnimationProgress = (progress: number, easing: AvatarAnimationEasing = 'linear') => {
+  const value = clamp(progress, 0, 1)
+  if (easing === 'ease-in') return value * value
+  if (easing === 'ease-out') return 1 - (1 - value) ** 2
+  if (easing === 'ease-in-out') return value < .5 ? 2 * value * value : 1 - ((-2 * value + 2) ** 2) / 2
+  return value
+}
+
+export const applyAvatarScenePatch = (scene: AvatarScene, patch: AvatarScenePatch): AvatarScene => ({
+  ...scene,
+  effects: {
+    ...scene.effects,
+    colorGrade: { ...scene.effects.colorGrade, ...patch.colorGrade }
+  },
+  entity: patch.entityParts == null
+    ? scene.entity
+    : {
+        ...scene.entity,
+        parts: scene.entity.parts.map(part => ({ ...part, ...patch.entityParts?.[part.id] }))
+      },
+  face: { ...scene.face, ...patch.face },
+  lighting: { ...scene.lighting, ...patch.lighting },
+  view: { ...scene.view, ...patch.view }
+})
+
+const interpolateRecord = <T extends object>(from: T, to: T, progress: number): T => {
+  const fromRecord = from as Record<string, unknown>
+  const toRecord = to as Record<string, unknown>
+  const result: Record<string, unknown> = { ...fromRecord }
+  Object.keys(toRecord).forEach(key => {
+    const fromValue = fromRecord[key]
+    const toValue = toRecord[key]
+    if (typeof fromValue === 'number' && typeof toValue === 'number') {
+      result[key] = interpolate(fromValue, toValue, progress)
+    } else {
+      result[key] = progress < 1 ? fromValue : toValue
+    }
+  })
+  return result as T
+}
+
+const interpolateScene = (from: AvatarScene, to: AvatarScene, progress: number): AvatarScene => ({
+  ...from,
+  effects: {
+    ...from.effects,
+    colorGrade: interpolateRecord(from.effects.colorGrade, to.effects.colorGrade, progress)
+  },
+  entity: {
+    ...from.entity,
+    parts: from.entity.parts.map(part => {
+      const target = to.entity.parts.find(candidate => candidate.id === part.id)
+      return target == null ? part : interpolateRecord(part, target, progress)
+    })
+  },
+  face: interpolateRecord(from.face, to.face, progress),
+  lighting: interpolateRecord(from.lighting, to.lighting, progress),
+  view: interpolateRecord(from.view, to.view, progress)
+})
+
+export const resolveAvatarAnimationFrame = (
+  definition: AvatarDefinition,
+  clip: AvatarAnimationClip,
+  elapsedMs: number
+): ResolvedAvatarAnimationFrame => {
+  const ordered = [...clip.keyframes].sort((a, b) => a.atMs - b.atMs)
+  if (ordered.length === 0 || clip.durationMs <= 0) {
+    return { elapsedMs: 0, finished: true, progress: 1, scene: definition.scene }
+  }
+  const requested = Math.max(elapsedMs, 0)
+  const finished = clip.playback === 'once' && requested >= clip.durationMs
+  const timeline = clip.playback === 'loop'
+    ? requested % clip.durationMs
+    : Math.min(requested, clip.durationMs)
+  let currentIndex = 0
+  ordered.forEach((frame, index) => {
+    if (frame.atMs <= timeline) currentIndex = index
+  })
+  const fromFrame = ordered[currentIndex]!
+  const nextFrame = ordered[currentIndex + 1]
+  const fromScene = applyAvatarScenePatch(definition.scene, fromFrame.patch)
+  if (nextFrame == null) {
+    if (clip.playback === 'once') {
+      return { elapsedMs: timeline, finished, progress: 1, scene: fromScene }
+    }
+    const toFrame = ordered[0]!
+    const span = Math.max(clip.durationMs - fromFrame.atMs + toFrame.atMs, 1)
+    const progress = easeAvatarAnimationProgress((timeline - fromFrame.atMs) / span, toFrame.easing)
+    return {
+      elapsedMs: timeline,
+      finished: false,
+      progress,
+      scene: interpolateScene(fromScene, applyAvatarScenePatch(definition.scene, toFrame.patch), progress)
+    }
+  }
+  const span = Math.max(nextFrame.atMs - fromFrame.atMs, 1)
+  const progress = easeAvatarAnimationProgress((timeline - fromFrame.atMs) / span, nextFrame.easing)
+  return {
+    elapsedMs: timeline,
+    finished,
+    progress,
+    scene: interpolateScene(fromScene, applyAvatarScenePatch(definition.scene, nextFrame.patch), progress)
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 export const AVATAR_DEFINITION_SCHEMA = 'oneworks.avatar' as const
 export const AVATAR_DEFINITION_VERSION = 1 as const
+export const AVATAR_ANIMATION_MIN_SEGMENT_MS = 100
+export const AVATAR_ANIMATION_MAX_SEGMENT_MS = 8000
 
 export type AvatarBackgroundStyle = 'gradient' | 'solid'
 export type AvatarBodyShape =
@@ -392,13 +394,32 @@ const isAvatarAnimationClip = (value: unknown): value is AvatarAnimationClip => 
     !isOneOf(value.playback, ['loop', 'once']) || !Array.isArray(value.keyframes) ||
     value.keyframes.length === 0) return false
   const durationMs = value.durationMs
-  return value.keyframes.every(keyframe => (
+  if (!value.keyframes.every(keyframe => (
     isRecord(keyframe) && isFiniteNumber(keyframe.atMs) && keyframe.atMs >= 0 &&
     keyframe.atMs <= durationMs &&
     (keyframe.easing == null || isOneOf(keyframe.easing, [
       'ease-in', 'ease-in-out', 'ease-out', 'linear'
     ])) && isAvatarScenePatch(keyframe.patch)
-  ))
+  ))) return false
+  const ordered = [...value.keyframes].sort((a, b) => a.atMs - b.atMs)
+  const timeline = ordered[0]!.atMs > 0
+    ? [{ atMs: 0 }, ...ordered]
+    : ordered
+  const segmentIsValid = (duration: number) => (
+    duration >= AVATAR_ANIMATION_MIN_SEGMENT_MS && duration <= AVATAR_ANIMATION_MAX_SEGMENT_MS
+  )
+  if (timeline.slice(1).some((frame, index) => (
+    !segmentIsValid(frame.atMs - timeline[index]!.atMs)
+  ))) return false
+  const tailDuration = durationMs - timeline.at(-1)!.atMs
+  return value.playback === 'loop'
+    ? segmentIsValid(tailDuration)
+    : tailDuration === 0 || segmentIsValid(tailDuration)
+}
+
+export const parseAvatarAnimationClip = (input: unknown): AvatarAnimationClip => {
+  if (!isAvatarAnimationClip(input)) throw new TypeError('Invalid OneWorks Avatar animation clip')
+  return structuredClone(input)
 }
 
 const isAvatarAnimationLibrary = (value: unknown): value is AvatarAnimationLibrary => (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -392,7 +392,7 @@ const isAvatarAnimationClip = (value: unknown): value is AvatarAnimationClip => 
   if (!isRecord(value) || !isOneOf(value.anchor, ['absolute', 'relative']) ||
     !isFiniteNumber(value.durationMs) || value.durationMs <= 0 || !isOptionalString(value.label) ||
     !isOneOf(value.playback, ['loop', 'once']) || !Array.isArray(value.keyframes) ||
-    value.keyframes.length === 0) return false
+    value.keyframes.length === 0 || (value.playback === 'loop' && value.keyframes.length < 2)) return false
   const durationMs = value.durationMs
   if (!value.keyframes.every(keyframe => (
     isRecord(keyframe) && isFiniteNumber(keyframe.atMs) && keyframe.atMs >= 0 &&

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": []
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,0 +1,17 @@
+import path from 'node:path'
+
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  plugins: [dts({ entryRoot: 'src', tsconfigPath: path.resolve(__dirname, 'tsconfig.json') })],
+  build: {
+    emptyOutDir: true,
+    lib: {
+      entry: path.resolve(__dirname, 'src/index.ts'),
+      fileName: 'index',
+      formats: ['es']
+    },
+    target: 'es2022'
+  }
+})

--- a/packages/react/LICENSE
+++ b/packages/react/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026-present One Works contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,15 @@
+# @oneworks/avatar-react
+
+[English](README.md) | [简体中文](README.zh-Hans.md)
+
+React renderer and embeddable full editor for OneWorks 3D Avatar.
+
+```tsx
+import { Avatar, AvatarEditor } from '@oneworks/avatar-react'
+import '@oneworks/avatar-react/style.css'
+
+<Avatar definition={avatar} animationLibraries={[supportAnimations]} />
+<AvatarEditor definition={avatar} animationLibraries={[supportAnimations]} />
+```
+
+See the [Avatar developer guide](https://oneworks.cloud/docs/en/usage/avatar#developer-integration).

--- a/packages/react/README.zh-Hans.md
+++ b/packages/react/README.zh-Hans.md
@@ -1,0 +1,15 @@
+# @oneworks/avatar-react
+
+[English](README.md) | [简体中文](README.zh-Hans.md)
+
+OneWorks 3D Avatar 的 React 渲染组件与可嵌入完整编辑器。
+
+```tsx
+import { Avatar, AvatarEditor } from '@oneworks/avatar-react'
+import '@oneworks/avatar-react/style.css'
+
+<Avatar definition={avatar} animationLibraries={[supportAnimations]} />
+<AvatarEditor definition={avatar} animationLibraries={[supportAnimations]} />
+```
+
+完整说明见 [Avatar 开发者接入指南](https://oneworks.cloud/docs/usage/avatar#开发者接入)。

--- a/packages/react/__tests__/lifecycle.spec.tsx
+++ b/packages/react/__tests__/lifecycle.spec.tsx
@@ -118,6 +118,31 @@ describe('OneWorks Avatar React lifecycle', () => {
     expect(ref.current?.getDefinition().scene.view.yaw).toBe(.9)
   })
 
+  it('does not restart autoplay after an interactive view change', () => {
+    const definition = createDefaultAvatarDefinition()
+    const clip: AvatarAnimationClip = {
+      anchor: 'absolute',
+      durationMs: 1000,
+      keyframes: [
+        { atMs: 0, patch: { view: { yaw: 0 } } },
+        { atMs: 1000, patch: { view: { yaw: .4 } } }
+      ],
+      playback: 'loop'
+    }
+    act(() =>
+      root?.render(createElement(Avatar, {
+        animation: clip,
+        autoplay: true,
+        definition,
+        interactive: true
+      }))
+    )
+    expect(animationFrames.size).toBe(1)
+
+    act(() => host?.querySelector<HTMLButtonElement>('[data-testid="view-change"]')?.click())
+    expect(animationFrames.size).toBe(0)
+  })
+
   it('reacts to locale prop changes', () => {
     const LocaleProbe = () => {
       const { t } = useAvatarLocale()

--- a/packages/react/__tests__/lifecycle.spec.tsx
+++ b/packages/react/__tests__/lifecycle.spec.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { act, createElement, createRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import type { Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../src/App', async () => {
+  const { createElement } = await import('react')
+  return {
+    default: ({ definition, onDefinitionChange }: {
+      definition: ReturnType<typeof createDefaultAvatarDefinition>
+      onDefinitionChange: (definition: ReturnType<typeof createDefaultAvatarDefinition>) => void
+    }) =>
+      createElement('button', {
+        'data-testid': 'editor-change',
+        onClick: () => onDefinitionChange({ ...definition, metadata: { id: 'edited' } })
+      }, 'Edit')
+  }
+})
+
+vi.mock('../../../src/InteractiveAvatar', async () => {
+  const { createElement } = await import('react')
+  return {
+    InteractiveAvatar: ({ onViewStateChange, viewState }: {
+      onViewStateChange: (view: ReturnType<typeof createDefaultAvatarDefinition>['scene']['view']) => void
+      viewState: ReturnType<typeof createDefaultAvatarDefinition>['scene']['view']
+    }) =>
+      createElement('button', {
+        'data-testid': 'view-change',
+        onClick: () => onViewStateChange({ ...viewState, yaw: .9 })
+      }, 'Change view')
+  }
+})
+
+import { createDefaultAvatarDefinition } from '@oneworks/avatar-core'
+import type { AvatarAnimationClip } from '@oneworks/avatar-core'
+
+import { AvatarLocaleProvider, useAvatarLocale } from '../../../src/avatarLocale'
+import { Avatar, AvatarEditor } from '../src'
+import type { AvatarEditorHandle, AvatarHandle } from '../src'
+
+let root: Root | null = null
+let host: HTMLDivElement | null = null
+let animationFrames: Map<number, FrameRequestCallback>
+let nextAnimationFrame: number
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  animationFrames = new Map()
+  nextAnimationFrame = 0
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((callback: FrameRequestCallback) => {
+      nextAnimationFrame += 1
+      animationFrames.set(nextAnimationFrame, callback)
+      return nextAnimationFrame
+    })
+  )
+  vi.stubGlobal(
+    'cancelAnimationFrame',
+    vi.fn((id: number) => {
+      animationFrames.delete(id)
+    })
+  )
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      addEventListener: vi.fn(),
+      matches: false,
+      removeEventListener: vi.fn()
+    }))
+  )
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  if (root != null) act(() => root?.unmount())
+  host?.remove()
+  root = null
+  host = null
+  vi.unstubAllGlobals()
+})
+
+describe('OneWorks Avatar React lifecycle', () => {
+  it('returns a newly controlled editor definition after an earlier edit', () => {
+    const first = createDefaultAvatarDefinition()
+    const second = { ...first, metadata: { id: 'second' } }
+    const ref = createRef<AvatarEditorHandle>()
+    act(() => root?.render(createElement(AvatarEditor, { definition: first, ref })))
+    act(() => host?.querySelector<HTMLButtonElement>('[data-testid="editor-change"]')?.click())
+    expect(ref.current?.getDefinition().metadata?.id).toBe('edited')
+
+    act(() => root?.render(createElement(AvatarEditor, { definition: second, ref })))
+    expect(ref.current?.getDefinition()).toEqual(second)
+  })
+
+  it('stops active playback before committing an interactive view change', async () => {
+    const definition = createDefaultAvatarDefinition()
+    const ref = createRef<AvatarHandle>()
+    const clip: AvatarAnimationClip = {
+      anchor: 'absolute',
+      durationMs: 1000,
+      keyframes: [
+        { atMs: 0, patch: { view: { yaw: 0 } } },
+        { atMs: 1000, patch: { view: { yaw: .4 } } }
+      ],
+      playback: 'loop'
+    }
+    act(() => root?.render(createElement(Avatar, { definition, interactive: true, ref })))
+    await act(async () => ref.current?.play(clip))
+    expect(animationFrames.size).toBe(1)
+
+    act(() => host?.querySelector<HTMLButtonElement>('[data-testid="view-change"]')?.click())
+    expect(animationFrames.size).toBe(0)
+    expect(ref.current?.getDefinition().scene.view.yaw).toBe(.9)
+  })
+
+  it('reacts to locale prop changes', () => {
+    const LocaleProbe = () => {
+      const { t } = useAvatarLocale()
+      return createElement('span', null, t('Size'))
+    }
+    act(() =>
+      root?.render(createElement(
+        AvatarLocaleProvider,
+        { initialLocale: 'en', persist: false },
+        createElement(LocaleProbe)
+      ))
+    )
+    expect(host?.textContent).toBe('Size')
+
+    act(() =>
+      root?.render(createElement(
+        AvatarLocaleProvider,
+        { initialLocale: 'zh-Hans', persist: false },
+        createElement(LocaleProbe)
+      ))
+    )
+    expect(host?.textContent).toBe('尺寸')
+  })
+})

--- a/packages/react/__tests__/lifecycle.spec.tsx
+++ b/packages/react/__tests__/lifecycle.spec.tsx
@@ -105,7 +105,7 @@ describe('OneWorks Avatar React lifecycle', () => {
       durationMs: 1000,
       keyframes: [
         { atMs: 0, patch: { view: { yaw: 0 } } },
-        { atMs: 1000, patch: { view: { yaw: .4 } } }
+        { atMs: 900, patch: { view: { yaw: .4 } } }
       ],
       playback: 'loop'
     }
@@ -125,7 +125,7 @@ describe('OneWorks Avatar React lifecycle', () => {
       durationMs: 1000,
       keyframes: [
         { atMs: 0, patch: { view: { yaw: 0 } } },
-        { atMs: 1000, patch: { view: { yaw: .4 } } }
+        { atMs: 900, patch: { view: { yaw: .4 } } }
       ],
       playback: 'loop'
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@oneworks/avatar-react",
+  "version": "0.1.0-alpha.0",
+  "description": "React renderer and embeddable editor for OneWorks 3D Avatar",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": ["./dist/style.css"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneworks-ai/avatar.git",
+    "directory": "packages/react"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./style.css": "./dist/style.css",
+    "./package.json": "./package.json"
+  },
+  "files": ["dist", "README.md", "README.zh-Hans.md"],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit --pretty false"
+  },
+  "dependencies": {
+    "@oneworks/avatar-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18.3.0 <20",
+    "react-dom": ">=18.3.0 <20"
+  },
+  "publishConfig": { "access": "public" }
+}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -291,7 +291,10 @@ export const Avatar = forwardRef<AvatarHandle, AvatarProps>(function Avatar({
         interactionMode={scene.interactionMode}
         lightDistance={scene.lighting.distance}
         lightDirection={{ azimuth: scene.lighting.azimuth, elevation: scene.lighting.elevation }}
-        onViewStateChange={view => commitDefinition(applyView(currentDefinition, view))}
+        onViewStateChange={view => {
+          stop()
+          commitDefinition(applyView(currentDefinition, view))
+        }}
         palette={palette}
         shadowStyle={scene.effects.faceShadow}
         showAvatarShadow={scene.effects.showAvatarShadow}
@@ -342,6 +345,7 @@ export const AvatarEditor = forwardRef<AvatarEditorHandle, AvatarEditorProps>(fu
 
   useEffect(() => {
     if (definition == null || definition === emittedRef.current) return
+    emittedRef.current = undefined
     setInternalDefinition(definition)
     setRevision(current => current + 1)
   }, [definition])

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,0 +1,385 @@
+import './style.scss'
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import type { CSSProperties, HTMLAttributes } from 'react'
+
+import { getAvatarPalette } from '@oneworks/avatar'
+import {
+  anchorAvatarAnimationClip,
+  createDefaultAvatarDefinition,
+  mergeAvatarAnimationLibraries,
+  resolveAvatarAnimationClip,
+  resolveAvatarAnimationFrame
+} from '@oneworks/avatar-core'
+import type {
+  AvatarAnimationClip,
+  AvatarAnimationLibrary,
+  AvatarAnimationRef,
+  AvatarDefinition
+} from '@oneworks/avatar-core'
+
+import App from '../../../src/App'
+import { InteractiveAvatar } from '../../../src/InteractiveAvatar'
+import type { AvatarViewState } from '../../../src/InteractiveAvatar'
+import { AvatarLocaleProvider } from '../../../src/avatarLocale'
+import { renderAvatarPngBlob, serializeAvatarSvg } from '../../../src/savedAvatarPresets'
+
+export type {
+  AvatarAnimationClip,
+  AvatarAnimationGroup,
+  AvatarAnimationKeyframe,
+  AvatarAnimationLibrary,
+  AvatarAnimationRef,
+  AvatarDefinition
+} from '@oneworks/avatar-core'
+
+export type AvatarTheme = 'dark' | 'light' | 'system'
+export type AvatarLocale = 'en' | 'zh-Hans'
+export type AvatarCaptureOptions = {
+  readonly background?: string | 'transparent'
+  readonly format: 'png' | 'svg'
+  readonly frame?: 'circle' | 'rounded' | 'square'
+  readonly size: 128 | 256 | 512
+}
+
+export interface AvatarPlayOptions {
+  readonly playback?: 'loop' | 'once'
+  readonly speed?: number
+}
+
+export interface AvatarHandle {
+  capture(options: AvatarCaptureOptions): Promise<Blob>
+  getDefinition(): AvatarDefinition
+  pause(): void
+  play(animation: AvatarAnimationClip | AvatarAnimationRef, options?: AvatarPlayOptions): Promise<void>
+  resume(): void
+  seek(timeMs: number): void
+  setDefinition(definition: AvatarDefinition): void
+  stop(options?: { readonly reset?: boolean }): void
+}
+
+export interface AvatarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onError'> {
+  readonly animation?: AvatarAnimationClip | AvatarAnimationRef | null
+  readonly animationLibraries?: readonly AvatarAnimationLibrary[]
+  readonly autoplay?: boolean
+  readonly definition?: AvatarDefinition
+  readonly interactive?: boolean
+  readonly onAnimationEnd?: () => void
+  readonly onAnimationLoop?: () => void
+  readonly onAnimationStart?: () => void
+  readonly onDefinitionChange?: (definition: AvatarDefinition) => void
+  readonly onError?: (error: Error) => void
+  readonly theme?: AvatarTheme
+}
+
+const resolveSystemTheme = () => (
+  typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+)
+
+const applyView = (definition: AvatarDefinition, view: AvatarViewState): AvatarDefinition => ({
+  ...definition,
+  scene: { ...definition.scene, view }
+})
+
+export const Avatar = forwardRef<AvatarHandle, AvatarProps>(function Avatar({
+  animation = null,
+  animationLibraries = [],
+  autoplay = false,
+  className,
+  definition: definitionProp,
+  interactive = false,
+  onAnimationEnd,
+  onAnimationLoop,
+  onAnimationStart,
+  onDefinitionChange,
+  onError,
+  style,
+  theme = 'system',
+  ...divProps
+}, ref) {
+  const defaultDefinitionRef = useRef<AvatarDefinition>()
+  if (defaultDefinitionRef.current == null) defaultDefinitionRef.current = createDefaultAvatarDefinition()
+  const definition = definitionProp ?? defaultDefinitionRef.current
+  const [currentDefinition, setCurrentDefinition] = useState(definition)
+  const [renderDefinition, setRenderDefinition] = useState(definition)
+  const [systemTheme, setSystemTheme] = useState(resolveSystemTheme)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const frameRef = useRef<number>()
+  const animationRef = useRef<{
+    base: AvatarDefinition
+    clip: AvatarAnimationClip
+    elapsedBeforeStart: number
+    lastLoop: number
+    playing: boolean
+    speed: number
+    startedAt: number
+  } | null>(null)
+  const callbacksRef = useRef({ onAnimationEnd, onAnimationLoop, onAnimationStart, onError })
+  callbacksRef.current = { onAnimationEnd, onAnimationLoop, onAnimationStart, onError }
+  const libraries = useMemo(() => mergeAvatarAnimationLibraries([
+    ...(currentDefinition.animations == null ? [] : [currentDefinition.animations]),
+    ...animationLibraries
+  ]), [animationLibraries, currentDefinition.animations])
+
+  useEffect(() => {
+    if (frameRef.current != null) cancelAnimationFrame(frameRef.current)
+    frameRef.current = undefined
+    animationRef.current = null
+    setCurrentDefinition(definition)
+    setRenderDefinition(definition)
+  }, [definition])
+
+  useEffect(() => {
+    if (theme !== 'system' || typeof window === 'undefined') return
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleChange = () => setSystemTheme(media.matches ? 'dark' : 'light')
+    media.addEventListener('change', handleChange)
+    return () => media.removeEventListener('change', handleChange)
+  }, [theme])
+
+  const commitDefinition = useCallback((next: AvatarDefinition) => {
+    setCurrentDefinition(next)
+    setRenderDefinition(next)
+    onDefinitionChange?.(next)
+  }, [onDefinitionChange])
+
+  const stopFrame = useCallback(() => {
+    if (frameRef.current != null) cancelAnimationFrame(frameRef.current)
+    frameRef.current = undefined
+  }, [])
+
+  const tick = useCallback((now: number) => {
+    const state = animationRef.current
+    if (state == null || !state.playing) return
+    const elapsed = state.elapsedBeforeStart + (now - state.startedAt) * state.speed
+    const frame = resolveAvatarAnimationFrame(state.base, state.clip, elapsed)
+    setRenderDefinition({ ...state.base, scene: frame.scene })
+    const loop = state.clip.durationMs > 0 ? Math.floor(elapsed / state.clip.durationMs) : 0
+    if (state.clip.playback === 'loop' && loop > state.lastLoop) {
+      state.lastLoop = loop
+      callbacksRef.current.onAnimationLoop?.()
+    }
+    if (frame.finished) {
+      animationRef.current = null
+      frameRef.current = undefined
+      callbacksRef.current.onAnimationEnd?.()
+      return
+    }
+    frameRef.current = requestAnimationFrame(tick)
+  }, [])
+
+  const play = useCallback(async (
+    requested: AvatarAnimationClip | AvatarAnimationRef,
+    options: AvatarPlayOptions = {}
+  ) => {
+    const selected = 'clipId' in requested ? resolveAvatarAnimationClip(libraries, requested) : requested
+    if (selected == null) {
+      const error = new Error('Unknown OneWorks Avatar animation')
+      callbacksRef.current.onError?.(error)
+      throw error
+    }
+    stopFrame()
+    const clip = anchorAvatarAnimationClip(currentDefinition, {
+      ...selected,
+      playback: options.playback ?? selected.playback
+    })
+    animationRef.current = {
+      base: currentDefinition,
+      clip,
+      elapsedBeforeStart: 0,
+      lastLoop: 0,
+      playing: true,
+      speed: Math.max(options.speed ?? 1, .01),
+      startedAt: performance.now()
+    }
+    callbacksRef.current.onAnimationStart?.()
+    frameRef.current = requestAnimationFrame(tick)
+  }, [currentDefinition, libraries, stopFrame, tick])
+
+  const stop = useCallback((options: { readonly reset?: boolean } = {}) => {
+    const state = animationRef.current
+    stopFrame()
+    animationRef.current = null
+    if (options.reset !== false) setRenderDefinition(state?.base ?? currentDefinition)
+  }, [currentDefinition, stopFrame])
+
+  useImperativeHandle(ref, () => ({
+    capture: async options => {
+      const svg = containerRef.current?.querySelector<SVGSVGElement>('svg.interactive-avatar__canvas')
+      if (svg == null) throw new Error('Avatar is not ready to capture')
+      const captureOptions = {
+        background: options.background ?? renderDefinition.scene.camera.background,
+        frame: options.frame ?? renderDefinition.scene.camera.frame
+      }
+      if (options.format === 'png') return renderAvatarPngBlob(svg, options.size, captureOptions)
+      return new Blob([serializeAvatarSvg(svg, options.size, captureOptions)], {
+        type: 'image/svg+xml;charset=utf-8'
+      })
+    },
+    getDefinition: () => currentDefinition,
+    pause: () => {
+      const state = animationRef.current
+      if (state == null || !state.playing) return
+      state.elapsedBeforeStart += (performance.now() - state.startedAt) * state.speed
+      state.playing = false
+      stopFrame()
+    },
+    play,
+    resume: () => {
+      const state = animationRef.current
+      if (state == null || state.playing) return
+      state.playing = true
+      state.startedAt = performance.now()
+      frameRef.current = requestAnimationFrame(tick)
+    },
+    seek: timeMs => {
+      const state = animationRef.current
+      if (state == null) return
+      state.elapsedBeforeStart = Math.max(timeMs, 0)
+      state.startedAt = performance.now()
+      const frame = resolveAvatarAnimationFrame(state.base, state.clip, state.elapsedBeforeStart)
+      setRenderDefinition({ ...state.base, scene: frame.scene })
+    },
+    setDefinition: commitDefinition,
+    stop
+  }), [commitDefinition, currentDefinition, play, renderDefinition, stop, stopFrame, tick])
+
+  useEffect(() => () => stopFrame(), [stopFrame])
+  useEffect(() => {
+    if (autoplay && animation != null) void play(animation)
+    return () => stopFrame()
+  }, [animation, autoplay, play, stopFrame])
+
+  const scene = renderDefinition.scene
+  const palette = getAvatarPalette(scene.appearance.paletteId)
+  const resolvedTheme = theme === 'system' ? systemTheme : theme
+  const mergedStyle = {
+    '--oneworks-avatar-background': scene.camera.background === 'transparent'
+      ? 'transparent'
+      : scene.camera.background,
+    ...style
+  } as CSSProperties
+
+  return (
+    <div
+      {...divProps}
+      ref={containerRef}
+      className={`oneworks-avatar ${resolvedTheme === 'dark' ? 'dark' : ''}${className == null ? '' : ` ${className}`}`}
+      data-frame={scene.camera.frame}
+      data-theme={resolvedTheme}
+      style={mergedStyle}
+    >
+      <InteractiveAvatar
+        avatarOutlineStyle={scene.effects.outline}
+        avatarShadowStyle={scene.effects.avatarShadow}
+        backgroundStyle={scene.appearance.backgroundStyle}
+        bodyShape={scene.appearance.bodyShape}
+        colorGrade={scene.effects.colorGrade}
+        entityParts={scene.entity.parts}
+        entityPreset={scene.entity.preset}
+        faceStyle={scene.face}
+        gridDensity={scene.lighting.gridDensity}
+        interactive={interactive}
+        interactionMode={scene.interactionMode}
+        lightDistance={scene.lighting.distance}
+        lightDirection={{ azimuth: scene.lighting.azimuth, elevation: scene.lighting.elevation }}
+        onViewStateChange={view => commitDefinition(applyView(currentDefinition, view))}
+        palette={palette}
+        shadowStyle={scene.effects.faceShadow}
+        showAvatarShadow={scene.effects.showAvatarShadow}
+        showLight={scene.lighting.enabled}
+        showOutline={scene.effects.showOutline}
+        showShadow={scene.effects.showFaceShadow}
+        viewState={scene.view}
+      />
+    </div>
+  )
+})
+
+export interface AvatarEditorHandle {
+  focus(): void
+  getDefinition(): AvatarDefinition
+  setDefinition(definition: AvatarDefinition): void
+}
+
+export interface AvatarEditorProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'> {
+  readonly animationLibraries?: readonly AvatarAnimationLibrary[]
+  readonly defaultDefinition?: AvatarDefinition
+  readonly definition?: AvatarDefinition
+  readonly locale?: AvatarLocale
+  readonly onDefinitionChange?: (definition: AvatarDefinition) => void
+  readonly theme?: AvatarTheme
+}
+
+export const AvatarEditor = forwardRef<AvatarEditorHandle, AvatarEditorProps>(function AvatarEditor({
+  animationLibraries = [],
+  className,
+  defaultDefinition: defaultDefinitionProp,
+  definition,
+  locale = 'en',
+  onDefinitionChange,
+  theme = 'system',
+  ...divProps
+}, ref) {
+  const defaultDefinitionRef = useRef<AvatarDefinition>()
+  if (defaultDefinitionRef.current == null) {
+    defaultDefinitionRef.current = defaultDefinitionProp ?? createDefaultAvatarDefinition()
+  }
+  const defaultDefinition = defaultDefinitionProp ?? defaultDefinitionRef.current
+  const containerRef = useRef<HTMLDivElement>(null)
+  const emittedRef = useRef<AvatarDefinition>()
+  const [internalDefinition, setInternalDefinition] = useState(definition ?? defaultDefinition)
+  const [revision, setRevision] = useState(0)
+  const value = internalDefinition
+
+  useEffect(() => {
+    if (definition == null || definition === emittedRef.current) return
+    setInternalDefinition(definition)
+    setRevision(current => current + 1)
+  }, [definition])
+
+  const handleChange = useCallback((next: AvatarDefinition) => {
+    emittedRef.current = next
+    setInternalDefinition(next)
+    onDefinitionChange?.(next)
+  }, [onDefinitionChange])
+
+  useImperativeHandle(ref, () => ({
+    focus: () => containerRef.current?.focus(),
+    getDefinition: () => emittedRef.current ?? value,
+    setDefinition: next => {
+      emittedRef.current = undefined
+      setInternalDefinition(next)
+      setRevision(current => current + 1)
+      onDefinitionChange?.(next)
+    }
+  }), [onDefinitionChange, value])
+
+  return (
+    <div
+      {...divProps}
+      ref={containerRef}
+      className={`oneworks-avatar-editor${className == null ? '' : ` ${className}`}`}
+      tabIndex={-1}
+    >
+      <AvatarLocaleProvider initialLocale={locale} persist={false}>
+        <App
+          key={revision}
+          animationLibraries={animationLibraries}
+          definition={value}
+          embedded
+          onDefinitionChange={handleChange}
+          theme={theme}
+        />
+      </AvatarLocaleProvider>
+    </div>
+  )
+})

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -203,6 +203,8 @@ export const Avatar = forwardRef<AvatarHandle, AvatarProps>(function Avatar({
     callbacksRef.current.onAnimationStart?.()
     frameRef.current = requestAnimationFrame(tick)
   }, [currentDefinition, libraries, stopFrame, tick])
+  const playRef = useRef(play)
+  playRef.current = play
 
   const stop = useCallback((options: { readonly reset?: boolean } = {}) => {
     const state = animationRef.current
@@ -254,9 +256,9 @@ export const Avatar = forwardRef<AvatarHandle, AvatarProps>(function Avatar({
 
   useEffect(() => () => stopFrame(), [stopFrame])
   useEffect(() => {
-    if (autoplay && animation != null) void play(animation)
+    if (autoplay && animation != null) void playRef.current(animation)
     return () => stopFrame()
-  }, [animation, autoplay, play, stopFrame])
+  }, [animation, autoplay, stopFrame])
 
   const scene = renderDefinition.scene
   const palette = getAvatarPalette(scene.appearance.paletteId)

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -16,6 +16,7 @@ import {
   anchorAvatarAnimationClip,
   createDefaultAvatarDefinition,
   mergeAvatarAnimationLibraries,
+  parseAvatarAnimationClip,
   resolveAvatarAnimationClip,
   resolveAvatarAnimationFrame
 } from '@oneworks/avatar-core'
@@ -187,10 +188,10 @@ export const Avatar = forwardRef<AvatarHandle, AvatarProps>(function Avatar({
       throw error
     }
     stopFrame()
-    const clip = anchorAvatarAnimationClip(currentDefinition, {
+    const clip = anchorAvatarAnimationClip(currentDefinition, parseAvatarAnimationClip({
       ...selected,
       playback: options.playback ?? selected.playback
-    })
+    }))
     animationRef.current = {
       base: currentDefinition,
       clip,

--- a/packages/react/src/style.scss
+++ b/packages/react/src/style.scss
@@ -1,0 +1,88 @@
+@import '@oneworks/route-layout/design-tokens.css';
+
+.oneworks-avatar,
+.oneworks-avatar-editor {
+  box-sizing: border-box;
+  color: var(--text-color);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+}
+
+.oneworks-avatar *,
+.oneworks-avatar-editor * {
+  box-sizing: border-box;
+}
+
+.oneworks-avatar {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  overflow: hidden;
+  background: var(--oneworks-avatar-background, transparent);
+}
+
+.oneworks-avatar[data-frame='rounded'] {
+  border-radius: 12.5%;
+}
+
+.oneworks-avatar[data-frame='circle'] {
+  border-radius: 50%;
+}
+
+.oneworks-avatar > .interactive-avatar {
+  width: 100%;
+  height: 100%;
+}
+
+.oneworks-avatar-editor {
+  position: relative;
+  display: block;
+  width: 100%;
+  min-width: 0;
+  min-height: 640px;
+  overflow: hidden;
+  background: var(--bg-color);
+}
+
+.oneworks-avatar-editor > .avatar-app {
+  min-height: inherit;
+}
+
+.oneworks-avatar-editor > .avatar-app.dark {
+  --app-chrome-overlay-background: color-mix(
+    in srgb,
+    var(--bg-color) 42%,
+    transparent
+  );
+  --bg-color: #141414;
+  --sub-bg-color: #262626;
+  --sub-sub-bg-color: #303030;
+  --text-color: #ffffff;
+  --sub-text-color: #8c8c8c;
+  --sub-sub-text-color: #a5a5a5;
+  --border-color: #303030;
+  --sub-border-color: #434343;
+  --sub-sub-border-color: #595959;
+  --placeholder-color: #575859;
+  --tag-bg: #1f1f1f;
+  --tag-hover-bg: #262626;
+  --code-bg: #1e293b;
+  --code-border: #334155;
+  --star-color: #ffb81c;
+  --primary-color: #e23f12;
+  --primary-soft-bg: color-mix(
+    in srgb,
+    var(--primary-color) 12%,
+    var(--bg-color)
+  );
+  --success-color: #2dd4bf;
+  --warning-color: #f59e0b;
+  --primary-text-color: color-mix(
+    in srgb,
+    var(--primary-color) 82%,
+    var(--text-color)
+  );
+  --danger-color: #f87171;
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.app-source.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "paths": {
+      "@oneworks/avatar": ["./app-source/packages/avatar/src/index.ts"],
+      "@oneworks/avatar/*": ["./app-source/packages/avatar/src/*.ts"]
+    }
+  },
+  "include": ["src/**/*", "../../src/**/*"]
+}

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  plugins: [
+    react(),
+    dts({
+      entryRoot: 'src',
+      include: ['src/**/*', '../../src/gifenc.d.ts'],
+      tsconfigPath: path.resolve(__dirname, 'tsconfig.json')
+    })
+  ],
+  resolve: {
+    alias: {
+      '@oneworks/avatar': path.resolve(__dirname, '../../app-source/packages/avatar/src/index.ts'),
+      '@oneworks/route-layout/design-tokens.css': path.resolve(
+        __dirname,
+        '../../app-source/packages/route-layout/src/design-tokens.css'
+      )
+    }
+  },
+  build: {
+    emptyOutDir: true,
+    lib: {
+      entry: path.resolve(__dirname, 'src/index.tsx'),
+      fileName: 'index',
+      formats: ['es']
+    },
+    rollupOptions: {
+      external: [
+        '@oneworks/avatar-core',
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime'
+      ]
+    },
+    target: 'es2022'
+  }
+})

--- a/packages/vue/LICENSE
+++ b/packages/vue/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026-present One Works contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,19 @@
+# @oneworks/avatar-vue
+
+[English](README.md) | [简体中文](README.zh-Hans.md)
+
+Vue renderer and embeddable full editor for OneWorks 3D Avatar.
+
+```vue
+<script setup lang="ts">
+import { OneWorksAvatar, OneWorksAvatarEditor } from '@oneworks/avatar-vue'
+import '@oneworks/avatar-vue/style.css'
+</script>
+
+<template>
+  <OneWorksAvatar :definition="avatar" :animation-libraries="[supportAnimations]" />
+  <OneWorksAvatarEditor :definition="avatar" @definition-change="avatar = $event" />
+</template>
+```
+
+See the [Avatar developer guide](https://oneworks.cloud/docs/en/usage/avatar#developer-integration).

--- a/packages/vue/README.zh-Hans.md
+++ b/packages/vue/README.zh-Hans.md
@@ -1,0 +1,19 @@
+# @oneworks/avatar-vue
+
+[English](README.md) | [简体中文](README.zh-Hans.md)
+
+OneWorks 3D Avatar 的 Vue 渲染组件与可嵌入完整编辑器。
+
+```vue
+<script setup lang="ts">
+import { OneWorksAvatar, OneWorksAvatarEditor } from '@oneworks/avatar-vue'
+import '@oneworks/avatar-vue/style.css'
+</script>
+
+<template>
+  <OneWorksAvatar :definition="avatar" :animation-libraries="[supportAnimations]" />
+  <OneWorksAvatarEditor :definition="avatar" @definition-change="avatar = $event" />
+</template>
+```
+
+完整说明见 [Avatar 开发者接入指南](https://oneworks.cloud/docs/usage/avatar#开发者接入)。

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@oneworks/avatar-vue",
+  "version": "0.1.0-alpha.0",
+  "description": "Vue renderer and embeddable editor for OneWorks 3D Avatar",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": ["./dist/style.css"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneworks-ai/avatar.git",
+    "directory": "packages/vue"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./style.css": "./dist/style.css",
+    "./package.json": "./package.json"
+  },
+  "files": ["dist", "README.md", "README.zh-Hans.md"],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "vue-tsc -p tsconfig.json --noEmit --pretty false"
+  },
+  "dependencies": {
+    "@oneworks/avatar-core": "workspace:*",
+    "@oneworks/avatar-web": "workspace:*"
+  },
+  "peerDependencies": {
+    "vue": ">=3.5.0 <4"
+  },
+  "publishConfig": { "access": "public" }
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,159 @@
+import './style.css'
+
+import {
+  defineComponent,
+  h,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch
+} from 'vue'
+import type { PropType } from 'vue'
+
+import type {
+  AvatarAnimationClip,
+  AvatarAnimationLibrary,
+  AvatarAnimationRef,
+  AvatarDefinition
+} from '@oneworks/avatar-core'
+import {
+  createAvatar,
+  createAvatarEditor
+} from '@oneworks/avatar-web'
+import type {
+  AvatarCaptureOptions,
+  AvatarEditorMount,
+  AvatarEditorMountOptions,
+  AvatarMount,
+  AvatarMountOptions,
+  AvatarPlayOptions,
+  AvatarTheme
+} from '@oneworks/avatar-web'
+
+export type {
+  AvatarAnimationClip,
+  AvatarAnimationGroup,
+  AvatarAnimationKeyframe,
+  AvatarAnimationLibrary,
+  AvatarAnimationRef,
+  AvatarCaptureOptions,
+  AvatarDefinition,
+  AvatarPlayOptions,
+  AvatarTheme
+} from '@oneworks/avatar-web'
+
+type AvatarAnimation = AvatarAnimationClip | AvatarAnimationRef | null
+
+const avatarProps = {
+  animation: { default: null, type: Object as PropType<AvatarAnimation> },
+  animationLibraries: { default: () => [], type: Array as PropType<readonly AvatarAnimationLibrary[]> },
+  autoplay: { default: false, type: Boolean },
+  definition: { default: undefined, type: Object as PropType<AvatarDefinition | undefined> },
+  interactive: { default: false, type: Boolean },
+  theme: { default: 'system', type: String as PropType<AvatarTheme> }
+}
+
+export const OneWorksAvatar = defineComponent({
+  emits: ['animation-end', 'animation-loop', 'animation-start', 'definition-change', 'error', 'ready'],
+  name: 'OneWorksAvatar',
+  props: avatarProps,
+  setup(props, { attrs, emit, expose }) {
+    const host = ref<HTMLElement | null>(null)
+    let mount: AvatarMount | null = null
+
+    const options = (): AvatarMountOptions => ({
+      animation: props.animation,
+      animationLibraries: props.animationLibraries,
+      autoplay: props.autoplay,
+      definition: props.definition,
+      interactive: props.interactive,
+      theme: props.theme
+    })
+
+    onMounted(() => {
+      if (host.value == null) return
+      mount = createAvatar(host.value, options())
+      host.value.addEventListener('animationend', () => emit('animation-end'))
+      host.value.addEventListener('animationloop', () => emit('animation-loop'))
+      host.value.addEventListener('animationstart', () => emit('animation-start'))
+      host.value.addEventListener('avatarchange', event => emit(
+        'definition-change',
+        (event as CustomEvent<{ definition: AvatarDefinition }>).detail.definition
+      ))
+      host.value.addEventListener('avatarerror', event => emit(
+        'error',
+        (event as CustomEvent<{ error: Error }>).detail.error
+      ))
+      void mount.ready.then(() => emit('ready'))
+    })
+    watch(() => [
+      props.animation,
+      props.animationLibraries,
+      props.autoplay,
+      props.definition,
+      props.interactive,
+      props.theme
+    ], () => mount?.update(options()))
+    onBeforeUnmount(() => mount?.destroy())
+
+    expose({
+      capture: (captureOptions: AvatarCaptureOptions) => mount!.capture(captureOptions),
+      getDefinition: () => mount!.getDefinition(),
+      pause: () => mount!.pause(),
+      play: (animation: Exclude<AvatarAnimation, null>, playOptions?: AvatarPlayOptions) => (
+        mount!.play(animation, playOptions)
+      ),
+      resume: () => mount!.resume(),
+      seek: (timeMs: number) => mount!.seek(timeMs),
+      setDefinition: (definition: AvatarDefinition) => mount!.setDefinition(definition),
+      stop: (options?: { readonly reset?: boolean }) => mount!.stop(options)
+    })
+
+    return () => h('div', { ...attrs, ref: host })
+  }
+})
+
+const editorProps = {
+  animationLibraries: { default: () => [], type: Array as PropType<readonly AvatarAnimationLibrary[]> },
+  definition: { default: undefined, type: Object as PropType<AvatarDefinition | undefined> },
+  locale: { default: 'en', type: String as PropType<'en' | 'zh-Hans'> },
+  theme: { default: 'system', type: String as PropType<AvatarTheme> }
+}
+
+export const OneWorksAvatarEditor = defineComponent({
+  emits: ['definition-change', 'ready'],
+  name: 'OneWorksAvatarEditor',
+  props: editorProps,
+  setup(props, { attrs, emit, expose }) {
+    const host = ref<HTMLElement | null>(null)
+    let mount: AvatarEditorMount | null = null
+    const options = (): AvatarEditorMountOptions => ({
+      animationLibraries: props.animationLibraries,
+      definition: props.definition,
+      locale: props.locale,
+      theme: props.theme
+    })
+
+    onMounted(() => {
+      if (host.value == null) return
+      mount = createAvatarEditor(host.value, options())
+      host.value.addEventListener('avatarchange', event => emit(
+        'definition-change',
+        (event as CustomEvent<{ definition: AvatarDefinition }>).detail.definition
+      ))
+      void mount.ready.then(() => emit('ready'))
+    })
+    watch(() => [props.animationLibraries, props.definition, props.locale, props.theme], () => {
+      mount?.update(options())
+    })
+    onBeforeUnmount(() => mount?.destroy())
+
+    expose({
+      focus: () => mount!.focus(),
+      getDefinition: () => mount!.getDefinition(),
+      setDefinition: (definition: AvatarDefinition) => mount!.setDefinition(definition)
+    })
+
+    return () => h('div', { ...attrs, ref: host })
+  }
+})

--- a/packages/vue/src/style.css
+++ b/packages/vue/src/style.css
@@ -1,0 +1,1 @@
+@import '@oneworks/avatar-web/style.css';

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": []
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -1,0 +1,24 @@
+import path from 'node:path'
+
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    dts({ entryRoot: 'src', tsconfigPath: path.resolve(__dirname, 'tsconfig.json') })
+  ],
+  build: {
+    emptyOutDir: true,
+    lib: {
+      entry: path.resolve(__dirname, 'src/index.ts'),
+      fileName: 'index',
+      formats: ['es']
+    },
+    rollupOptions: {
+      external: ['@oneworks/avatar-core', '@oneworks/avatar-web', 'vue']
+    },
+    target: 'es2022'
+  }
+})

--- a/packages/web/LICENSE
+++ b/packages/web/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026-present One Works contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,17 @@
+# @oneworks/avatar-web
+
+[English](README.md) | [简体中文](README.zh-Hans.md)
+
+Vanilla JavaScript mounts and opt-in Web Components for OneWorks 3D Avatar.
+
+```ts
+import { createAvatar, createAvatarEditor } from '@oneworks/avatar-web'
+import '@oneworks/avatar-web/style.css'
+
+const avatar = createAvatar(document.querySelector('#avatar')!, { definition })
+const editor = createAvatarEditor(document.querySelector('#editor')!, { definition })
+```
+
+Custom elements are registered only when you call `registerAvatarElements()` from `@oneworks/avatar-web/elements`.
+
+See the [Avatar developer guide](https://oneworks.cloud/docs/en/usage/avatar#developer-integration).

--- a/packages/web/README.zh-Hans.md
+++ b/packages/web/README.zh-Hans.md
@@ -1,0 +1,17 @@
+# @oneworks/avatar-web
+
+[English](README.md) | [简体中文](README.zh-Hans.md)
+
+OneWorks 3D Avatar 的原生 JavaScript 挂载 API 与可选 Web Component。
+
+```ts
+import { createAvatar, createAvatarEditor } from '@oneworks/avatar-web'
+import '@oneworks/avatar-web/style.css'
+
+const avatar = createAvatar(document.querySelector('#avatar')!, { definition })
+const editor = createAvatarEditor(document.querySelector('#editor')!, { definition })
+```
+
+Web Component 不会自动注册；只有调用 `@oneworks/avatar-web/elements` 的 `registerAvatarElements()` 后才会写入全局注册表。
+
+完整说明见 [Avatar 开发者接入指南](https://oneworks.cloud/docs/usage/avatar#开发者接入)。

--- a/packages/web/__tests__/elements.spec.ts
+++ b/packages/web/__tests__/elements.spec.ts
@@ -1,17 +1,58 @@
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  OneWorksAvatarEditorElement,
-  OneWorksAvatarElement,
-  registerAvatarElements
-} from '../src/elements'
+const mounts = vi.hoisted(() => {
+  const createAvatar = vi.fn((_element: HTMLElement, options: { definition: unknown }) => {
+    let definition = options.definition
+    return {
+      capture: vi.fn(),
+      destroy: vi.fn(),
+      getDefinition: () => definition,
+      pause: vi.fn(),
+      play: vi.fn(),
+      ready: Promise.resolve(),
+      resume: vi.fn(),
+      seek: vi.fn(),
+      setDefinition: (next: unknown) => {
+        definition = next
+      },
+      stop: vi.fn(),
+      update: vi.fn((next: { definition?: unknown }) => {
+        if (next.definition != null) definition = next.definition
+      })
+    }
+  })
+  const createAvatarEditor = vi.fn((_element: HTMLElement, options: { definition: unknown }) => {
+    let definition = options.definition
+    return {
+      destroy: vi.fn(),
+      focus: vi.fn(),
+      getDefinition: () => definition,
+      ready: Promise.resolve(),
+      setDefinition: (next: unknown) => {
+        definition = next
+      },
+      update: vi.fn((next: { definition?: unknown }) => {
+        if (next.definition != null) definition = next.definition
+      })
+    }
+  })
+  return { createAvatar, createAvatarEditor }
+})
+
+vi.mock('../src/index', () => mounts)
+
+import { createDefaultAvatarDefinition } from '@oneworks/avatar-core'
+
+import { OneWorksAvatarEditorElement, OneWorksAvatarElement, registerAvatarElements } from '../src/elements'
 
 const mounted: Element[] = []
 
 afterEach(() => {
   mounted.splice(0).forEach(element => element.remove())
+  mounts.createAvatar.mockClear()
+  mounts.createAvatarEditor.mockClear()
 })
 
 describe('OneWorks Avatar custom elements', () => {
@@ -25,5 +66,26 @@ describe('OneWorks Avatar custom elements', () => {
     registerAvatarElements()
     expect(customElements.get('oneworks-avatar')).toBe(OneWorksAvatarElement)
     expect(customElements.get('oneworks-avatar-editor')).toBe(OneWorksAvatarEditorElement)
+  })
+
+  it('preserves runtime and editor definitions across disconnect and reconnect', () => {
+    registerAvatarElements()
+    const definition = {
+      ...createDefaultAvatarDefinition(),
+      metadata: { id: 'reconnected' }
+    }
+    const avatar = document.createElement('oneworks-avatar')
+    const editor = document.createElement('oneworks-avatar-editor')
+    mounted.push(avatar, editor)
+    document.body.append(avatar, editor)
+    avatar.definition = definition
+    editor.definition = definition
+
+    avatar.remove()
+    editor.remove()
+    document.body.append(avatar, editor)
+
+    expect(mounts.createAvatar.mock.calls.at(-1)?.[1].definition).toEqual(definition)
+    expect(mounts.createAvatarEditor.mock.calls.at(-1)?.[1].definition).toEqual(definition)
   })
 })

--- a/packages/web/__tests__/elements.spec.ts
+++ b/packages/web/__tests__/elements.spec.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  OneWorksAvatarEditorElement,
+  OneWorksAvatarElement,
+  registerAvatarElements
+} from '../src/elements'
+
+const mounted: Element[] = []
+
+afterEach(() => {
+  mounted.splice(0).forEach(element => element.remove())
+})
+
+describe('OneWorks Avatar custom elements', () => {
+  it('does not register elements as an import side effect', () => {
+    expect(customElements.get('oneworks-avatar')).toBeUndefined()
+    expect(customElements.get('oneworks-avatar-editor')).toBeUndefined()
+  })
+
+  it('registers the public tags explicitly and idempotently', () => {
+    registerAvatarElements()
+    registerAvatarElements()
+    expect(customElements.get('oneworks-avatar')).toBe(OneWorksAvatarElement)
+    expect(customElements.get('oneworks-avatar-editor')).toBe(OneWorksAvatarEditorElement)
+  })
+})

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@oneworks/avatar-web",
+  "version": "0.1.0-alpha.0",
+  "description": "Vanilla JavaScript runtime, editor mounts, and Web Components for OneWorks 3D Avatar",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": ["./dist/style.css"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneworks-ai/avatar.git",
+    "directory": "packages/web"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./elements": {
+      "types": "./dist/elements.d.ts",
+      "default": "./dist/elements.js"
+    },
+    "./style.css": "./dist/style.css",
+    "./package.json": "./package.json"
+  },
+  "files": ["dist", "README.md", "README.zh-Hans.md"],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit --pretty false"
+  },
+  "dependencies": {
+    "@oneworks/avatar-core": "workspace:*",
+    "@oneworks/avatar-react": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "publishConfig": { "access": "public" }
+}

--- a/packages/web/src/elements.ts
+++ b/packages/web/src/elements.ts
@@ -1,0 +1,157 @@
+import { createDefaultAvatarDefinition } from '@oneworks/avatar-core'
+import type {
+  AvatarAnimationClip,
+  AvatarAnimationLibrary,
+  AvatarAnimationRef,
+  AvatarDefinition
+} from '@oneworks/avatar-core'
+
+import { createAvatar, createAvatarEditor } from './index'
+import type {
+  AvatarEditorMount,
+  AvatarEditorMountOptions,
+  AvatarMount,
+  AvatarMountOptions
+} from './index'
+
+const readBooleanAttribute = (element: Element, name: string) => element.hasAttribute(name)
+
+export class OneWorksAvatarElement extends HTMLElement {
+  static observedAttributes = ['autoplay', 'interactive', 'theme']
+
+  #animation: AvatarAnimationClip | AvatarAnimationRef | null = null
+  #animationLibraries: readonly AvatarAnimationLibrary[] = []
+  #definition: AvatarDefinition = createDefaultAvatarDefinition()
+  #mount: AvatarMount | null = null
+
+  get animation() { return this.#animation }
+  set animation(value) {
+    this.#animation = value
+    this.#update()
+  }
+
+  get animationLibraries() { return this.#animationLibraries }
+  set animationLibraries(value) {
+    this.#animationLibraries = value
+    this.#update()
+  }
+
+  get definition() { return this.#mount?.getDefinition() ?? this.#definition }
+  set definition(value) {
+    this.#definition = value
+    if (this.#mount == null) this.#update()
+    else this.#mount.setDefinition(value)
+  }
+
+  connectedCallback() { this.#update() }
+  disconnectedCallback() {
+    this.#mount?.destroy()
+    this.#mount = null
+  }
+  attributeChangedCallback() { this.#update() }
+
+  capture(options: Parameters<AvatarMount['capture']>[0]) { return this.#requireMount().capture(options) }
+  pause() { this.#requireMount().pause() }
+  play(animation: AvatarAnimationClip | AvatarAnimationRef, options?: Parameters<AvatarMount['play']>[1]) {
+    return this.#requireMount().play(animation, options)
+  }
+  resume() { this.#requireMount().resume() }
+  seek(timeMs: number) { this.#requireMount().seek(timeMs) }
+  stop(options?: Parameters<AvatarMount['stop']>[0]) { this.#requireMount().stop(options) }
+
+  #options(): AvatarMountOptions {
+    const theme = this.getAttribute('theme')
+    return {
+      animation: this.#animation,
+      animationLibraries: this.#animationLibraries,
+      autoplay: readBooleanAttribute(this, 'autoplay'),
+      definition: this.#definition,
+      interactive: readBooleanAttribute(this, 'interactive'),
+      theme: theme === 'dark' || theme === 'light' ? theme : 'system'
+    }
+  }
+
+  #requireMount() {
+    if (this.#mount == null) throw new Error('OneWorks Avatar element is not connected')
+    return this.#mount
+  }
+
+  #update() {
+    if (!this.isConnected) return
+    const options = this.#options()
+    if (this.#mount == null) this.#mount = createAvatar(this, options)
+    else this.#mount.update(options)
+  }
+}
+
+export class OneWorksAvatarEditorElement extends HTMLElement {
+  static observedAttributes = ['locale', 'theme']
+
+  #animationLibraries: readonly AvatarAnimationLibrary[] = []
+  #definition: AvatarDefinition = createDefaultAvatarDefinition()
+  #mount: AvatarEditorMount | null = null
+
+  get animationLibraries() { return this.#animationLibraries }
+  set animationLibraries(value) {
+    this.#animationLibraries = value
+    this.#update()
+  }
+
+  get definition() { return this.#mount?.getDefinition() ?? this.#definition }
+  set definition(value) {
+    this.#definition = value
+    if (this.#mount == null) this.#update()
+    else this.#mount.setDefinition(value)
+  }
+
+  connectedCallback() { this.#update() }
+  disconnectedCallback() {
+    this.#mount?.destroy()
+    this.#mount = null
+  }
+  attributeChangedCallback() { this.#update() }
+  focus(options?: FocusOptions) {
+    super.focus(options)
+    this.#mount?.focus()
+  }
+
+  #options(): AvatarEditorMountOptions {
+    const locale = this.getAttribute('locale')
+    const theme = this.getAttribute('theme')
+    return {
+      animationLibraries: this.#animationLibraries,
+      definition: this.#definition,
+      locale: locale === 'zh-Hans' ? locale : 'en',
+      theme: theme === 'dark' || theme === 'light' ? theme : 'system'
+    }
+  }
+
+  #update() {
+    if (!this.isConnected) return
+    const options = this.#options()
+    if (this.#mount == null) this.#mount = createAvatarEditor(this, options)
+    else this.#mount.update(options)
+  }
+}
+
+export interface RegisterAvatarElementsOptions {
+  readonly registry?: CustomElementRegistry
+}
+
+export const registerAvatarElements = ({
+  registry = customElements
+}: RegisterAvatarElementsOptions = {}) => {
+  if (registry.get('oneworks-avatar') == null) {
+    registry.define('oneworks-avatar', OneWorksAvatarElement)
+  }
+  if (registry.get('oneworks-avatar-editor') == null) {
+    registry.define('oneworks-avatar-editor', OneWorksAvatarEditorElement)
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'oneworks-avatar': OneWorksAvatarElement
+    'oneworks-avatar-editor': OneWorksAvatarEditorElement
+  }
+}

--- a/packages/web/src/elements.ts
+++ b/packages/web/src/elements.ts
@@ -45,7 +45,10 @@ export class OneWorksAvatarElement extends HTMLElement {
 
   connectedCallback() { this.#update() }
   disconnectedCallback() {
-    this.#mount?.destroy()
+    if (this.#mount != null) {
+      this.#definition = this.#mount.getDefinition()
+      this.#mount.destroy()
+    }
     this.#mount = null
   }
   attributeChangedCallback() { this.#update() }
@@ -106,7 +109,10 @@ export class OneWorksAvatarEditorElement extends HTMLElement {
 
   connectedCallback() { this.#update() }
   disconnectedCallback() {
-    this.#mount?.destroy()
+    if (this.#mount != null) {
+      this.#definition = this.#mount.getDefinition()
+      this.#mount.destroy()
+    }
     this.#mount = null
   }
   attributeChangedCallback() { this.#update() }

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,0 +1,190 @@
+import './style.css'
+
+import { createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import type { Root } from 'react-dom/client'
+
+import { createDefaultAvatarDefinition } from '@oneworks/avatar-core'
+import type {
+  AvatarAnimationClip,
+  AvatarAnimationLibrary,
+  AvatarAnimationRef,
+  AvatarDefinition
+} from '@oneworks/avatar-core'
+import { Avatar, AvatarEditor } from '@oneworks/avatar-react'
+import type {
+  AvatarCaptureOptions,
+  AvatarEditorHandle,
+  AvatarHandle,
+  AvatarPlayOptions,
+  AvatarTheme
+} from '@oneworks/avatar-react'
+
+export type {
+  AvatarAnimationClip,
+  AvatarAnimationGroup,
+  AvatarAnimationKeyframe,
+  AvatarAnimationLibrary,
+  AvatarAnimationRef,
+  AvatarDefinition
+} from '@oneworks/avatar-core'
+export type { AvatarCaptureOptions, AvatarPlayOptions, AvatarTheme } from '@oneworks/avatar-react'
+
+export interface AvatarMountOptions {
+  readonly animation?: AvatarAnimationClip | AvatarAnimationRef | null
+  readonly animationLibraries?: readonly AvatarAnimationLibrary[]
+  readonly autoplay?: boolean
+  readonly definition?: AvatarDefinition
+  readonly interactive?: boolean
+  readonly theme?: AvatarTheme
+}
+
+export interface AvatarEditorMountOptions {
+  readonly animationLibraries?: readonly AvatarAnimationLibrary[]
+  readonly definition?: AvatarDefinition
+  readonly locale?: 'en' | 'zh-Hans'
+  readonly theme?: AvatarTheme
+}
+
+export interface AvatarMount extends AvatarHandle {
+  readonly ready: Promise<void>
+  destroy(): void
+  update(options: Partial<AvatarMountOptions>): void
+}
+
+export interface AvatarEditorMount extends AvatarEditorHandle {
+  readonly ready: Promise<void>
+  destroy(): void
+  update(options: Partial<AvatarEditorMountOptions>): void
+}
+
+const dispatch = <T>(element: HTMLElement, type: string, detail?: T) => {
+  element.dispatchEvent(new CustomEvent(type, { bubbles: true, composed: true, detail }))
+}
+
+export const createAvatar = (
+  element: HTMLElement,
+  initialOptions: AvatarMountOptions = {}
+): AvatarMount => {
+  let options = initialOptions
+  let handle: AvatarHandle | null = null
+  let destroyed = false
+  let resolveReady: () => void = () => {}
+  const ready = new Promise<void>(resolve => {
+    resolveReady = resolve
+  })
+  const root: Root = createRoot(element)
+
+  const render = () => {
+    if (destroyed) return
+    root.render(createElement(Avatar, {
+      ...options,
+      ref: (next: AvatarHandle | null) => {
+        if (handle == null && next != null) {
+          resolveReady()
+          dispatch(element, 'avatarready')
+        }
+        handle = next
+      },
+      onAnimationEnd: () => dispatch(element, 'animationend'),
+      onAnimationLoop: () => dispatch(element, 'animationloop'),
+      onAnimationStart: () => dispatch(element, 'animationstart'),
+      onDefinitionChange: definition => dispatch(element, 'avatarchange', { definition }),
+      onError: error => dispatch(element, 'avatarerror', { error })
+    }))
+  }
+  const requireHandle = () => {
+    if (destroyed) throw new Error('OneWorks Avatar mount has been destroyed')
+    if (handle == null) throw new Error('OneWorks Avatar is not ready')
+    return handle
+  }
+
+  render()
+  return {
+    capture: async captureOptions => {
+      await ready
+      return requireHandle().capture(captureOptions)
+    },
+    destroy: () => {
+      if (destroyed) return
+      destroyed = true
+      handle = null
+      root.unmount()
+    },
+    getDefinition: () => handle?.getDefinition() ?? options.definition ?? createDefaultAvatarDefinition(),
+    pause: () => requireHandle().pause(),
+    play: async (animation, playOptions) => {
+      await ready
+      return requireHandle().play(animation, playOptions)
+    },
+    ready,
+    resume: () => requireHandle().resume(),
+    seek: timeMs => requireHandle().seek(timeMs),
+    setDefinition: definition => {
+      options = { ...options, definition }
+      if (handle == null) render()
+      else handle.setDefinition(definition)
+    },
+    stop: stopOptions => requireHandle().stop(stopOptions),
+    update: nextOptions => {
+      options = { ...options, ...nextOptions }
+      render()
+    }
+  }
+}
+
+export const createAvatarEditor = (
+  element: HTMLElement,
+  initialOptions: AvatarEditorMountOptions = {}
+): AvatarEditorMount => {
+  let options = initialOptions
+  let handle: AvatarEditorHandle | null = null
+  let destroyed = false
+  let resolveReady: () => void = () => {}
+  const ready = new Promise<void>(resolve => {
+    resolveReady = resolve
+  })
+  const root = createRoot(element)
+
+  const render = () => {
+    if (destroyed) return
+    root.render(createElement(AvatarEditor, {
+      ...options,
+      ref: (next: AvatarEditorHandle | null) => {
+        if (handle == null && next != null) {
+          resolveReady()
+          dispatch(element, 'editoready')
+        }
+        handle = next
+      },
+      onDefinitionChange: definition => dispatch(element, 'avatarchange', { definition })
+    }))
+  }
+  const requireHandle = () => {
+    if (destroyed) throw new Error('OneWorks Avatar editor mount has been destroyed')
+    if (handle == null) throw new Error('OneWorks Avatar editor is not ready')
+    return handle
+  }
+
+  render()
+  return {
+    destroy: () => {
+      if (destroyed) return
+      destroyed = true
+      handle = null
+      root.unmount()
+    },
+    focus: () => requireHandle().focus(),
+    getDefinition: () => handle?.getDefinition() ?? options.definition ?? createDefaultAvatarDefinition(),
+    ready,
+    setDefinition: definition => {
+      options = { ...options, definition }
+      if (handle == null) render()
+      else handle.setDefinition(definition)
+    },
+    update: nextOptions => {
+      options = { ...options, ...nextOptions }
+      render()
+    }
+  }
+}

--- a/packages/web/src/style.css
+++ b/packages/web/src/style.css
@@ -1,0 +1,1 @@
+@import '@oneworks/avatar-react/style.css';

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": []
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path'
+
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  plugins: [dts({ entryRoot: 'src', tsconfigPath: path.resolve(__dirname, 'tsconfig.json') })],
+  build: {
+    emptyOutDir: true,
+    lib: {
+      entry: {
+        elements: path.resolve(__dirname, 'src/elements.ts'),
+        index: path.resolve(__dirname, 'src/index.ts')
+      },
+      formats: ['es']
+    },
+    cssCodeSplit: false,
+    rollupOptions: {
+      external: [
+        '@oneworks/avatar-core',
+        '@oneworks/avatar-react',
+        'react',
+        'react-dom/client'
+      ],
+      output: { entryFileNames: '[name].js' }
+    },
+    target: 'es2022'
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,13 @@ importers:
     dependencies:
       '@oneworks/avatar':
         specifier: beta
-        version: 0.1.0-beta.5
+        version: 0.1.0-beta.10
+      '@oneworks/avatar-core':
+        specifier: workspace:*
+        version: link:packages/core
       '@oneworks/route-layout':
         specifier: beta
-        version: 0.1.0-beta.5(react@18.3.1)
+        version: 0.1.0-beta.10(react@18.3.1)
       gifenc:
         specifier: ^1.0.3
         version: 1.0.3
@@ -27,6 +30,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.2
         version: 5.2.0(vite@5.4.21(sass@1.101.0))
+      '@vitejs/plugin-vue':
+        specifier: ^5.2.4
+        version: 5.2.4(vite@5.4.21(sass@1.101.0))(vue@3.5.41(typescript@5.9.3))
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -42,546 +51,895 @@ importers:
       vite:
         specifier: ^5.4.8
         version: 5.4.21(sass@1.101.0)
+      vite-plugin-dts:
+        specifier: ^4.5.4
+        version: 4.5.4(rollup@4.62.2)(typescript@5.9.3)(vite@5.4.21(sass@1.101.0))
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(jsdom@26.1.0)(sass@1.101.0)
+      vue:
+        specifier: ^3.5.21
+        version: 3.5.41(typescript@5.9.3)
+      vue-tsc:
+        specifier: ^2.2.12
+        version: 2.2.12(typescript@5.9.3)
+
+  packages/core: {}
+
+  packages/react:
+    dependencies:
+      '@oneworks/avatar-core':
+        specifier: workspace:*
+        version: link:../core
+      react:
+        specifier: '>=18.3.0 <20'
+        version: 18.3.1
+      react-dom:
+        specifier: '>=18.3.0 <20'
+        version: 18.3.1(react@18.3.1)
+
+  packages/vue:
+    dependencies:
+      '@oneworks/avatar-core':
+        specifier: workspace:*
+        version: link:../core
+      '@oneworks/avatar-web':
+        specifier: workspace:*
+        version: link:../web
+      vue:
+        specifier: '>=3.5.0 <4'
+        version: 3.5.41(typescript@5.9.3)
+
+  packages/web:
+    dependencies:
+      '@oneworks/avatar-core':
+        specifier: workspace:*
+        version: link:../core
+      '@oneworks/avatar-react':
+        specifier: workspace:*
+        version: link:../react
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
 
 packages:
 
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
   '@babel/code-frame@7.29.7':
-    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==, tarball: https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz}
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.29.7':
-    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==, tarball: https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz}
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.29.7':
-    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==, tarball: https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz}
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.7':
-    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==, tarball: https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz}
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.29.7':
-    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==, tarball: https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz}
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.29.7':
-    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==, tarball: https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz}
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.29.7':
-    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==, tarball: https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz}
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.29.7':
-    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==, tarball: https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz}
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
   '@babel/helper-plugin-utils@7.29.7':
-    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==, tarball: https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz}
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.29.7':
-    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==, tarball: https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz}
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
-    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==, tarball: https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz}
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.29.7':
-    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==, tarball: https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz}
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.29.7':
-    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==, tarball: https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz}
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==, tarball: https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz}
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
   '@babel/plugin-transform-react-jsx-self@7.29.7':
-    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==, tarball: https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz}
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-transform-react-jsx-source@7.29.7':
-    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==, tarball: https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz}
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/template@7.29.7':
-    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==, tarball: https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz}
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.7':
-    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==, tarball: https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz}
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==, tarball: https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz}
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
   '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz}
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz}
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz}
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz}
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz}
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz}
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz}
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz}
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz}
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz}
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz}
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz}
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz}
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz}
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz}
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz}
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz}
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz}
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz}
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz}
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz}
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz}
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz}
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
 
   '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==, tarball: https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz}
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
   '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==, tarball: https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz}
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==, tarball: https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz}
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==, tarball: https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz}
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==, tarball: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz}
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@oneworks/avatar@0.1.0-beta.5':
-    resolution: {integrity: sha512-jfHq+lm6wLd6w+KF73NOjR+n6Fi0+1bNvYtUxvxwH+YI7+aniPG2boXsUEaJiGNrnwSU+9FjdAcy8fKsNlLMYw==, tarball: https://registry.npmjs.org/@oneworks/avatar/-/avatar-0.1.0-beta.5.tgz}
+  '@microsoft/api-extractor-model@7.33.11':
+    resolution: {integrity: sha512-iDu1AtuRC2Z8XVs2SieZieVavF1FXPBX1C9pMexJh8Dx/Dd/3ZZ4nRQp/PU2Vk2rUHWuBz1wOyL4DcuhVnBXwg==}
+    engines: {node: '>=20.9.0'}
 
-  '@oneworks/icon@0.1.0-beta.5':
-    resolution: {integrity: sha512-IjRuCJpBddBrJkx5Sx42fyNlmN57JFPYuyCogcyX3WXBsMWFDXQpoGO8XL6qLbOTS0PIma2QVWvIFcYCiwTyJw==, tarball: https://registry.npmjs.org/@oneworks/icon/-/icon-0.1.0-beta.5.tgz}
+  '@microsoft/api-extractor@7.59.0':
+    resolution: {integrity: sha512-KDYV8kSVjmG8JJWVg1f1aKxteNG1IQ44D07Rjhlcci8wlqrSFNhUfgv7dJhwT0W2h3NDIL5Vz2f+/DfO4OpDHw==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
 
-  '@oneworks/route-layout@0.1.0-beta.5':
-    resolution: {integrity: sha512-NGTuRpj1ho1Nq7YvYF006p3O3t367JJl3UIe4gqyt0hhhgGrT6F4rK0ZZwbHKEsz1sNo2pIjPdNlmudAlydv4A==, tarball: https://registry.npmjs.org/@oneworks/route-layout/-/route-layout-0.1.0-beta.5.tgz}
+  '@microsoft/tsdoc-config@0.18.1':
+    resolution: {integrity: sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==}
+
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@oneworks/avatar@0.1.0-beta.10':
+    resolution: {integrity: sha512-ceWQG2HRG9/sUEBEJAbpcXgQOks5bveI+OOXnLjH7Hm/S3coagpZsjdt9dd3FTyvN9o0woAkl+IjbLUga6vP2Q==}
+
+  '@oneworks/icon@0.1.0-beta.10':
+    resolution: {integrity: sha512-1sE+Enefrv1kyg8rwOyDs2cQCsPMbU469NXKYxCi1r36wk7FEw8iTi0rMjcH2bhPqa0NKm355OVG/zKwegZzqg==}
+
+  '@oneworks/route-layout@0.1.0-beta.10':
+    resolution: {integrity: sha512-lNcTHCvC1zfrPiZP6hyGvssy8anz562S9oZOJtNSjuPVOCapwRmanLwi6uRGbt8KZJuHSAbV2G2RVL9+vEcY1A==}
     peerDependencies:
       react: ^18.3.1
 
   '@paper-design/shaders@0.0.76':
-    resolution: {integrity: sha512-AcNDY4J66YQHUfQYFInkCP7M9VOje0od7wLpOR7LtCmc532opJy6ll+h1W9zBovz8tt9U7OADUmJ/qKEXyOX/A==, tarball: https://registry.npmjs.org/@paper-design/shaders/-/shaders-0.0.76.tgz}
+    resolution: {integrity: sha512-AcNDY4J66YQHUfQYFInkCP7M9VOje0od7wLpOR7LtCmc532opJy6ll+h1W9zBovz8tt9U7OADUmJ/qKEXyOX/A==}
 
   '@parcel/watcher-android-arm64@2.5.6':
-    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==, tarball: https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz}
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [android]
 
   '@parcel/watcher-darwin-arm64@2.5.6':
-    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==, tarball: https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz}
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   '@parcel/watcher-darwin-x64@2.5.6':
-    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==, tarball: https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz}
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [darwin]
 
   '@parcel/watcher-freebsd-x64@2.5.6':
-    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==, tarball: https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz}
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [freebsd]
 
   '@parcel/watcher-linux-arm-glibc@2.5.6':
-    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz}
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
-    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz}
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
-    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz}
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
-    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz}
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
-    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz}
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
-    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz}
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
-    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==, tarball: https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz}
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [win32]
 
   '@parcel/watcher-win32-ia32@2.5.6':
-    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==, tarball: https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz}
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
     engines: {node: '>= 10.0.0'}
     cpu: [ia32]
     os: [win32]
 
   '@parcel/watcher-win32-x64@2.5.6':
-    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==, tarball: https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz}
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [win32]
 
   '@parcel/watcher@2.5.6':
-    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==, tarball: https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz}
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
   '@rolldown/pluginutils@1.0.0-rc.3':
-    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==, tarball: https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz}
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
-    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz}
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.62.2':
-    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz}
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
     cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-darwin-arm64@4.62.2':
-    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz}
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.62.2':
-    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz}
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
     cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-freebsd-arm64@4.62.2':
-    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==, tarball: https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz}
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.62.2':
-    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==, tarball: https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz}
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
     cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
-    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz}
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
-    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz}
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
-    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz}
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
-    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz}
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
-    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz}
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
-    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz}
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
-    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz}
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
-    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz}
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
-    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz}
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
-    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz}
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz}
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
-    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz}
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
-    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz}
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
-    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==, tarball: https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz}
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
     os: [openbsd]
 
   '@rollup/rollup-openharmony-arm64@4.62.2':
-    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==, tarball: https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz}
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
-    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz}
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
-    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz}
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
     cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-x64-gnu@4.62.2':
-    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz}
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
     cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
-    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz}
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
 
+  '@rushstack/node-core-library@5.24.0':
+    resolution: {integrity: sha512-g/Z47ZwARn/VkTnHcyJslrR26erRf1G5JbqPlfGZGBCrOcrEt8fTQXXDVhUDDNl/g/v3TXI1dNiAAT5FEks8BA==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/problem-matcher@0.2.1':
+    resolution: {integrity: sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/rig-package@0.7.3':
+    resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==}
+
+  '@rushstack/terminal@0.24.3':
+    resolution: {integrity: sha512-KxphDhPGC4xDrKg8O4yrWCEpPMi87aJc1iycXqMVh1dLgV0M34hiH9ZTgWjBRmcrT/OIHoOeWf48npcQFzgp+g==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/ts-command-line@5.3.13':
+    resolution: {integrity: sha512-+jNbxhh8CkrZYxMk9X3GRYM2+Myr1xCCj+eHbJ9Vp+PCdNHS0TUl5QQFT6UbM/aTFRCzs5jiBTKYzBRpe5uYbQ==}
+    engines: {node: '>=20.9.0'}
+
+  '@types/argparse@1.0.38':
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
   '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==, tarball: https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz}
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
   '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==, tarball: https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz}
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
 
   '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==, tarball: https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz}
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
 
   '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==, tarball: https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz}
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
-    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==, tarball: https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz}
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==, tarball: https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz}
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
   '@types/react-dom@18.3.7':
-    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==, tarball: https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz}
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
       '@types/react': ^18.0.0
 
   '@types/react@18.3.31':
-    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==, tarball: https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz}
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
   '@vitejs/plugin-react@5.2.0':
-    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==, tarball: https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz}
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  '@volar/language-core@2.4.15':
+    resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.15':
+    resolution: {integrity: sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.15':
+    resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vue/compiler-core@3.5.41':
+    resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
+
+  '@vue/compiler-dom@3.5.41':
+    resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
+
+  '@vue/compiler-sfc@3.5.41':
+    resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
+
+  '@vue/compiler-ssr@3.5.41':
+    resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/language-core@2.2.0':
+    resolution: {integrity: sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/language-core@2.2.12':
+    resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/reactivity@3.5.41':
+    resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
+
+  '@vue/runtime-core@3.5.41':
+    resolution: {integrity: sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==}
+
+  '@vue/runtime-dom@3.5.41':
+    resolution: {integrity: sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==}
+
+  '@vue/server-renderer@3.5.41':
+    resolution: {integrity: sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==}
+
+  '@vue/shared@3.5.41':
+    resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  alien-signals@0.4.14:
+    resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
+
+  alien-signals@1.0.13:
+    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.10.41:
-    resolution: {integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==, tarball: https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz}
+    resolution: {integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
   browserslist@4.28.4:
-    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==, tarball: https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz}
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001800:
-    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==, tarball: https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz}
+    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@5.0.0:
-    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==, tarball: https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz}
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
   convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==, tarball: https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz}
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
-    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==, tarball: https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz}
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==, tarball: https://registry.npmjs.org/debug/-/debug-4.4.3.tgz}
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -589,142 +947,453 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==, tarball: https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz}
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   electron-to-chromium@1.5.387:
-    resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==, tarball: https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz}
+    resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==, tarball: https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz}
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
 
   escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==, tarball: https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz}
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  exsolve@1.1.1:
+    resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fs-extra@11.3.6:
+    resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
+    engines: {node: '>=14.14'}
+
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==, tarball: https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz}
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
   gifenc@1.0.3:
     resolution: {integrity: sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   immutable@5.1.9:
-    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==, tarball: https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz}
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
+
+  import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==, tarball: https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz}
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
   is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==, tarball: https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz}
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
   js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==, tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz}
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==, tarball: https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz}
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==, tarball: https://registry.npmjs.org/json5/-/json5-2.2.3.tgz}
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
+
   loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==, tarball: https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz}
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz}
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==, tarball: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz}
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
   nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==, tarball: https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz}
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==, tarball: https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz}
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-releases@2.0.50:
-    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==, tarball: https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz}
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==, tarball: https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz}
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==, tarball: https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz}
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
   postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==, tarball: https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz}
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
   react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==, tarball: https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz}
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
 
   react-refresh@0.18.0:
-    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==, tarball: https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz}
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
   react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==, tarball: https://registry.npmjs.org/react/-/react-18.3.1.tgz}
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
   readdirp@5.0.0:
-    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==, tarball: https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz}
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   rollup@4.62.2:
-    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==, tarball: https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz}
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sass@1.101.0:
-    resolution: {integrity: sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==, tarball: https://registry.npmjs.org/sass/-/sass-1.101.0.tgz}
+    resolution: {integrity: sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==, tarball: https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz}
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==, tarball: https://registry.npmjs.org/semver/-/semver-6.3.1.tgz}
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==, tarball: https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz}
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
   typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==, tarball: https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz}
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite-plugin-dts@4.5.4:
+    resolution: {integrity: sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==}
+    peerDependencies:
+      typescript: '*'
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==, tarball: https://registry.npmjs.org/vite/-/vite-5.4.21.tgz}
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -754,10 +1423,108 @@ packages:
       terser:
         optional: true
 
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-tsc@2.2.12:
+    resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  vue@3.5.41:
+    resolution: {integrity: sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==, tarball: https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz}
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -838,6 +1605,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -870,6 +1641,31 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -959,15 +1755,50 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@oneworks/avatar@0.1.0-beta.5': {}
+  '@microsoft/api-extractor-model@7.33.11':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.24.0
+    transitivePeerDependencies:
+      - '@types/node'
 
-  '@oneworks/icon@0.1.0-beta.5':
+  '@microsoft/api-extractor@7.59.0':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.33.11
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.24.0
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.24.3
+      '@rushstack/ts-command-line': 5.3.13
+      diff: 8.0.4
+      minimatch: 10.2.3
+      resolve: 1.22.12
+      semver: 7.7.4
+      source-map: 0.6.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/tsdoc-config@0.18.1':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      ajv: 8.18.0
+      jju: 1.4.0
+      resolve: 1.22.12
+
+  '@microsoft/tsdoc@0.16.0': {}
+
+  '@oneworks/avatar@0.1.0-beta.10': {}
+
+  '@oneworks/icon@0.1.0-beta.10':
     dependencies:
       '@paper-design/shaders': 0.0.76
 
-  '@oneworks/route-layout@0.1.0-beta.5(react@18.3.1)':
+  '@oneworks/route-layout@0.1.0-beta.10(react@18.3.1)':
     dependencies:
-      '@oneworks/icon': 0.1.0-beta.5
+      '@oneworks/icon': 0.1.0-beta.10
       react: 18.3.1
 
   '@paper-design/shaders@0.0.76': {}
@@ -1034,6 +1865,14 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.5
+    optionalDependencies:
+      rollup: 4.62.2
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
@@ -1110,6 +1949,41 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@rushstack/node-core-library@5.24.0':
+    dependencies:
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      fs-extra: 11.3.6
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.12
+      semver: 7.7.4
+
+  '@rushstack/problem-matcher@0.2.1': {}
+
+  '@rushstack/rig-package@0.7.3':
+    dependencies:
+      jju: 1.4.0
+      resolve: 1.22.12
+
+  '@rushstack/terminal@0.24.3':
+    dependencies:
+      '@rushstack/node-core-library': 5.24.0
+      '@rushstack/problem-matcher': 0.2.1
+      supports-color: 8.1.1
+
+  '@rushstack/ts-command-line@5.3.13':
+    dependencies:
+      '@rushstack/terminal': 0.24.3
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@types/argparse@1.0.38': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.7
@@ -1130,6 +2004,13 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -1156,7 +2037,211 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(sass@1.101.0))(vue@3.5.41(typescript@5.9.3))':
+    dependencies:
+      vite: 5.4.21(sass@1.101.0)
+      vue: 3.5.41(typescript@5.9.3)
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@5.4.21(sass@1.101.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(sass@1.101.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@volar/language-core@2.4.15':
+    dependencies:
+      '@volar/source-map': 2.4.15
+
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.15': {}
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.15':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.41
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.41':
+    dependencies:
+      '@vue/compiler-core': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/compiler-sfc@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.41
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/shared': 3.5.41
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.26
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.41':
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/language-core@2.2.0(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.41
+      alien-signals: 0.4.14
+      minimatch: 9.0.9
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@vue/language-core@2.2.12(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.41
+      alien-signals: 1.0.13
+      minimatch: 9.0.9
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@vue/reactivity@3.5.41':
+    dependencies:
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-core@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-dom@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/runtime-core': 3.5.41
+      '@vue/shared': 3.5.41
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.41':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/shared@3.5.41': {}
+
+  acorn@8.18.0: {}
+
+  agent-base@7.1.4: {}
+
+  ajv-draft-04@1.0.0(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  alien-signals@0.4.14: {}
+
+  alien-signals@1.0.13: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  assertion-error@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.41: {}
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.4:
     dependencies:
@@ -1166,24 +2251,68 @@ snapshots:
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001800: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
 
+  compare-versions@6.1.1: {}
+
+  confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
+
   convert-source-map@2.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  de-indent@1.0.2: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
+
   detect-libc@2.1.2:
     optional: true
 
+  diff@8.0.4: {}
+
   electron-to-chromium@1.5.387: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -1213,14 +2342,78 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  exsolve@1.1.1: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.5: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fs-extra@11.3.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
   gifenc@1.0.3: {}
 
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  he@1.2.0: {}
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   immutable@5.1.9: {}
+
+  import-lazy@4.0.0: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
 
   is-extglob@2.1.1:
     optional: true
@@ -1230,39 +2423,150 @@ snapshots:
       is-extglob: 2.1.1
     optional: true
 
+  is-potential-custom-element-name@1.0.1: {}
+
+  jju@1.4.0: {}
+
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json5@2.2.3: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  kolorist@1.8.0: {}
+
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
+      quansync: 0.2.11
 
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  minimatch@10.2.3:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   nanoid@3.3.15: {}
+
+  nanoid@3.3.18: {}
 
   node-addon-api@7.1.1:
     optional: true
 
   node-releases@2.0.50: {}
 
+  nwsapi@2.2.24: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  path-browserify@1.0.1: {}
+
+  path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
-  picomatch@4.0.5:
-    optional: true
+  picomatch@4.0.5: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.1.1
+      pathe: 2.0.3
 
   postcss@8.5.16:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  punycode@2.3.1: {}
+
+  quansync@0.2.11: {}
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -1277,6 +2581,15 @@ snapshots:
       loose-envify: 1.4.0
 
   readdirp@5.0.0: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   rollup@4.62.2:
     dependencies:
@@ -1309,6 +2622,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
   sass@1.101.0:
     dependencies:
       chokidar: 5.0.0
@@ -1317,21 +2634,121 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.6
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
 
   semver@6.3.1: {}
 
+  semver@7.7.4: {}
+
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
+  sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  string-argv@0.3.2: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
   typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  universalify@2.0.1: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.4):
     dependencies:
       browserslist: 4.28.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  vite-node@3.2.4(sass@1.101.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(sass@1.101.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-plugin-dts@4.5.4(rollup@4.62.2)(typescript@5.9.3)(vite@5.4.21(sass@1.101.0)):
+    dependencies:
+      '@microsoft/api-extractor': 7.59.0
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 2.2.0(typescript@5.9.3)
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      kolorist: 1.8.0
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      typescript: 5.9.3
+    optionalDependencies:
+      vite: 5.4.21(sass@1.101.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
 
   vite@5.4.21(sass@1.101.0):
     dependencies:
@@ -1341,5 +2758,89 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
       sass: 1.101.0
+
+  vitest@3.2.7(jsdom@26.1.0)(sass@1.101.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@5.4.21(sass@1.101.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(sass@1.101.0)
+      vite-node: 3.2.4(sass@1.101.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vscode-uri@3.1.0: {}
+
+  vue-tsc@2.2.12(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.15
+      '@vue/language-core': 2.2.12(typescript@5.9.3)
+      typescript: 5.9.3
+
+  vue@3.5.41(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-sfc': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/server-renderer': 3.5.41
+      '@vue/shared': 3.5.41
+    optionalDependencies:
+      typescript: 5.9.3
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.21.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - packages/*
+
 allowBuilds:
   '@parcel/watcher': true
   esbuild: true

--- a/scripts/smoke-sdk-packages.mjs
+++ b/scripts/smoke-sdk-packages.mjs
@@ -1,0 +1,152 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, mkdir, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'oneworks-avatar-sdk-'))
+const tarballDirectory = path.join(temporaryRoot, 'tarballs')
+const consumerDirectory = path.join(temporaryRoot, 'consumer')
+const packages = [
+  '@oneworks/avatar-core',
+  '@oneworks/avatar-react',
+  '@oneworks/avatar-web',
+  '@oneworks/avatar-vue'
+]
+
+const run = (command, args, cwd) => {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: '0' },
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout)
+    process.stderr.write(result.stderr)
+    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`)
+  }
+  return result.stdout
+}
+
+try {
+  await mkdir(tarballDirectory, { recursive: true })
+  await mkdir(path.join(consumerDirectory, 'src'), { recursive: true })
+  run('pnpm', ['build:sdk'], root)
+  for (const packageName of packages) {
+    run('pnpm', ['--filter', packageName, 'pack', '--pack-destination', tarballDirectory], root)
+  }
+
+  const tarballs = await readdir(tarballDirectory)
+  const fileDependency = packageName => {
+    const prefix = packageName.replace('@oneworks/', 'oneworks-')
+    const tarball = tarballs.find(file => file.startsWith(prefix) && file.endsWith('.tgz'))
+    if (tarball == null) throw new Error(`Missing tarball for ${packageName}`)
+    return `file:${path.join(tarballDirectory, tarball)}`
+  }
+
+  await writeFile(path.join(consumerDirectory, 'package.json'), `${JSON.stringify({
+    dependencies: Object.fromEntries(packages.map(packageName => [packageName, fileDependency(packageName)])),
+    devDependencies: {
+      '@types/react': '18.3.31',
+      '@types/react-dom': '18.3.7',
+      react: '18.3.1',
+      'react-dom': '18.3.1',
+      typescript: '5.9.3',
+      vite: '5.4.21',
+      vue: '3.5.41'
+    },
+    name: 'oneworks-avatar-sdk-smoke',
+    private: true,
+    scripts: { build: 'tsc --noEmit && vite build' },
+    type: 'module'
+  }, null, 2)}\n`)
+  await writeFile(path.join(consumerDirectory, 'pnpm-workspace.yaml'), [
+    'packages:',
+    "  - '.'",
+    'overrides:',
+    ...packages.map(packageName => `  '${packageName}': '${fileDependency(packageName)}'`),
+    'allowBuilds:',
+    '  esbuild: true',
+    ''
+  ].join('\n'))
+  await writeFile(path.join(consumerDirectory, 'tsconfig.json'), `${JSON.stringify({
+    compilerOptions: {
+      lib: ['ES2022', 'DOM'],
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      strict: true,
+      target: 'ES2022'
+    },
+    include: ['src']
+  }, null, 2)}\n`)
+  await writeFile(path.join(consumerDirectory, 'index.html'), [
+    '<!doctype html>',
+    '<html><body>',
+    '<div id="react-avatar"></div><div id="web-avatar"></div><div id="vue-avatar"></div>',
+    '<script type="module" src="/src/main.ts"></script>',
+    '</body></html>',
+    ''
+  ].join('\n'))
+  await writeFile(path.join(consumerDirectory, 'src/main.ts'), `
+import { createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { createApp } from 'vue'
+import { createDefaultAvatarDefinition } from '@oneworks/avatar-core'
+import type { AvatarAnimationLibrary } from '@oneworks/avatar-core'
+import { Avatar, AvatarEditor } from '@oneworks/avatar-react'
+import '@oneworks/avatar-react/style.css'
+import { createAvatar, createAvatarEditor } from '@oneworks/avatar-web'
+import { registerAvatarElements } from '@oneworks/avatar-web/elements'
+import '@oneworks/avatar-web/style.css'
+import { OneWorksAvatar, OneWorksAvatarEditor } from '@oneworks/avatar-vue'
+import '@oneworks/avatar-vue/style.css'
+
+const definition = createDefaultAvatarDefinition()
+const animations: AvatarAnimationLibrary = {
+  id: 'support',
+  groups: {
+    attention: {
+      defaultClip: 'nod',
+      clips: {
+        nod: {
+          anchor: 'relative',
+          durationMs: 600,
+          playback: 'once',
+          keyframes: [
+            { atMs: 0, patch: { view: { pitch: 0 } } },
+            { atMs: 300, patch: { view: { pitch: .2 } } },
+            { atMs: 600, patch: { view: { pitch: 0 } } }
+          ]
+        }
+      }
+    }
+  }
+}
+
+createRoot(document.querySelector('#react-avatar')!).render(createElement(Avatar, {
+  animationLibraries: [animations],
+  definition
+}))
+void createElement(AvatarEditor, { animationLibraries: [animations], definition })
+createAvatar(document.querySelector('#web-avatar')!, { animationLibraries: [animations], definition })
+void createAvatarEditor(document.createElement('div'), { animationLibraries: [animations], definition })
+createApp(OneWorksAvatar, { animationLibraries: [animations], definition })
+  .mount(document.querySelector('#vue-avatar')!)
+void OneWorksAvatarEditor
+registerAvatarElements()
+const avatarElement = document.createElement('oneworks-avatar')
+avatarElement.definition = definition
+avatarElement.animationLibraries = [animations]
+const editorElement = document.createElement('oneworks-avatar-editor')
+editorElement.definition = definition
+editorElement.animationLibraries = [animations]
+`)
+
+  run('pnpm', ['install'], consumerDirectory)
+  run('pnpm', ['build'], consumerDirectory)
+  process.stdout.write('OneWorks Avatar SDK package smoke passed.\n')
+} finally {
+  await rm(temporaryRoot, { force: true, recursive: true })
+}

--- a/src/AnimationPanel.tsx
+++ b/src/AnimationPanel.tsx
@@ -35,12 +35,14 @@ interface AnimationPanelProps {
   readonly onPlay: () => void
   readonly onPlaybackModeChange: (mode: AvatarAnimationPlaybackMode) => void
   readonly onPresetSelect: (preset: AvatarAnimationPreset) => boolean
+  readonly onPublicAnimationSelect: (animation: SavedAvatarAnimation) => boolean
   readonly onSavedAnimationRemove: (animation: SavedAvatarAnimation) => void
   readonly onSavedAnimationSelect: (animation: SavedAvatarAnimation) => boolean
   readonly onSave: () => void
   readonly onStartFrameChange: (index: number) => void
   readonly onStop: () => void
   readonly playbackMode: AvatarAnimationPlaybackMode
+  readonly publicAnimations: readonly SavedAvatarAnimation[]
   readonly renderKeyframePreview: (keyframe: AvatarAnimationKeyframe) => ReactNode
   readonly renderPresetPreview: (preset: AvatarAnimationPreset) => ReactNode
   readonly requiresReplacementConfirmation: boolean
@@ -54,6 +56,7 @@ type AnimationPanelTab = 'create' | 'playback'
 type PendingAnimationAction =
   | { readonly animation: SavedAvatarAnimation; readonly type: 'remove-saved' }
   | { readonly animation: SavedAvatarAnimation; readonly type: 'replace-saved' }
+  | { readonly animation: SavedAvatarAnimation; readonly type: 'replace-public' }
   | { readonly preset: AvatarAnimationPreset; readonly type: 'replace-preset' }
 
 const DEFAULT_PANEL_HEIGHT = 244
@@ -116,12 +119,14 @@ export function AnimationPanel({
   onPlay,
   onPlaybackModeChange,
   onPresetSelect,
+  onPublicAnimationSelect,
   onSavedAnimationRemove,
   onSavedAnimationSelect,
   onSave,
   onStartFrameChange,
   onStop,
   playbackMode,
+  publicAnimations,
   renderKeyframePreview,
   renderPresetPreview,
   requiresReplacementConfirmation,
@@ -193,11 +198,20 @@ export function AnimationPanel({
     onSavedAnimationSelect(animation)
   }
 
+  const requestPublicAnimationSelection = (animation: SavedAvatarAnimation) => {
+    if (requiresReplacementConfirmation) {
+      setPendingAction({ animation, type: 'replace-public' })
+      return
+    }
+    onPublicAnimationSelect(animation)
+  }
+
   const confirmPendingAction = () => {
     const action = pendingAction
     setPendingAction(null)
     if (action == null) return
     if (action.type === 'replace-preset') onPresetSelect(action.preset)
+    else if (action.type === 'replace-public') onPublicAnimationSelect(action.animation)
     else if (action.type === 'replace-saved') onSavedAnimationSelect(action.animation)
     else onSavedAnimationRemove(action.animation)
   }
@@ -429,6 +443,25 @@ export function AnimationPanel({
                         {renderPresetPreview(preset)}
                       </span>
                       <span className='avatar-animation-panel__library-name'>{preset.label}</span>
+                    </button>
+                  )
+                })}
+                {publicAnimations.map(animation => {
+                  const previewKeyframe = animation.keyframes[animation.startFrameIndex]
+                  return (
+                    <button
+                      key={animation.id}
+                      className='avatar-animation-panel__library-item'
+                      type='button'
+                      aria-label={`Play ${animation.name}`}
+                      aria-pressed={selectedLibraryId === animation.id}
+                      title={`${animation.name} · ${animation.keyframes.length} keyframes`}
+                      onClick={() => requestPublicAnimationSelection(animation)}
+                    >
+                      <span className='avatar-animation-panel__library-preview' aria-hidden='true'>
+                        {previewKeyframe == null ? null : renderKeyframePreview(previewKeyframe)}
+                      </span>
+                      <span className='avatar-animation-panel__library-name'>{animation.name}</span>
                     </button>
                   )
                 })}

--- a/src/App.scss
+++ b/src/App.scss
@@ -298,6 +298,21 @@
   }
 }
 
+.avatar-app[data-embedded='true'] {
+  height: 100%;
+  min-height: inherit;
+
+  .avatar-app__workspace,
+  .avatar-app__workspace[data-animation-open='true'] {
+    height: 100%;
+    min-height: inherit;
+  }
+
+  .avatar-app__stage {
+    min-height: inherit;
+  }
+}
+
 .avatar-orientation-control {
   position: absolute;
   z-index: 3;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ import type { SavedAvatarPreset } from './savedAvatarPresets'
 import { LAST_EDITOR_QUERY_STORAGE_KEY } from './avatarHome'
 import { createAvatarGif } from './avatarGifExport'
 import {
+  avatarDefinitionToState,
   avatarDefinitionToSearchParams,
   createAvatarDefinition,
   flattenAvatarAnimationLibraries
@@ -215,6 +216,9 @@ const parseAvatarShadowColor = (value: string | null) => {
     ? value.toLowerCase()
     : DEFAULT_AVATAR_SHADOW_STYLE.color
 }
+const parseOptionalShadowColor = (value: string | null) => (
+  value != null && /^#[\da-f]{6}$/i.test(value) ? value.toLowerCase() : undefined
+)
 const parseCameraFrame = (value: string | null): AvatarCameraFrame => {
   return value === 'circle' || value === 'rounded' || value === 'square' ? value : DEFAULT_CAMERA_FRAME
 }
@@ -322,6 +326,9 @@ const parseQueryConfig = (params: URLSearchParams): AvatarQueryConfig => {
       eyeShape: parseEyeShape(params.get('eyeShape')),
       gap: parseRangeValue(params.get('eyeGap'), DEFAULT_AVATAR_FACE_STYLE.gap, 0, 100),
       height: parseRangeValue(params.get('eyeH'), DEFAULT_AVATAR_FACE_STYLE.height, 20, 104),
+      leftEyeHeight: params.has('eyeLeftH')
+        ? parseRangeValue(params.get('eyeLeftH'), DEFAULT_AVATAR_FACE_STYLE.height, 20, 104)
+        : undefined,
       leftEyeRotation: parseRangeValue(
         params.get('eyeLeftRot'),
         DEFAULT_AVATAR_FACE_STYLE.leftEyeRotation,
@@ -348,9 +355,13 @@ const parseQueryConfig = (params: URLSearchParams): AvatarQueryConfig => {
         -90,
         90
       ),
+      rightEyeHeight: params.has('eyeRightH')
+        ? parseRangeValue(params.get('eyeRightH'), DEFAULT_AVATAR_FACE_STYLE.height, 20, 104)
+        : undefined,
       width: parseRangeValue(params.get('eyeW'), DEFAULT_AVATAR_FACE_STYLE.width, 12, 72)
     },
     faceShadowStyle: {
+      color: parseOptionalShadowColor(params.get('shadowColor')),
       direction: parseRangeValue(
         params.get('shadowDir'),
         DEFAULT_AVATAR_FACE_SHADOW_STYLE.direction,
@@ -362,6 +373,7 @@ const parseQueryConfig = (params: URLSearchParams): AvatarQueryConfig => {
       softness: parseRangeValue(params.get('shadowSoft'), DEFAULT_AVATAR_FACE_SHADOW_STYLE.softness, 0, 12)
     },
     frameShadowStyle: {
+      color: parseOptionalShadowColor(params.get('frameShadowColor')),
       direction: parseRangeValue(params.get('frameShadowDir'), DEFAULT_FRAME_SHADOW_STYLE.direction, -180, 180),
       distance: parseRangeValue(params.get('frameShadowDist'), DEFAULT_FRAME_SHADOW_STYLE.distance, 0, 40),
       opacity: parseRangeValue(params.get('frameShadowOpacity'), DEFAULT_FRAME_SHADOW_STYLE.opacity, 0, 100),
@@ -419,6 +431,40 @@ const getInitialQueryConfig = (definition?: AvatarDefinition) => {
     ? typeof window === 'undefined' ? new URLSearchParams() : new URLSearchParams(window.location.search)
     : avatarDefinitionToSearchParams(definition)
   const config = parseQueryConfig(params)
+  if (definition != null) {
+    const state = avatarDefinitionToState(definition)
+    return {
+      ...config,
+      avatarOutlineStyle: state.avatarOutlineStyle,
+      avatarShadowStyle: state.avatarShadowStyle,
+      backgroundStyle: state.backgroundStyle,
+      bodyShape: state.bodyShape,
+      cameraBackground: state.cameraBackground,
+      cameraFrame: state.cameraFrame,
+      entityParts: state.entityParts,
+      entityPreset: state.entityPreset,
+      exportSize: state.exportSize,
+      faceShadowStyle: state.faceShadowStyle,
+      faceStyle: state.faceStyle,
+      frameShadowStyle: state.frameShadowStyle,
+      gridDensity: state.gridDensity,
+      interactionMode: state.interactionMode,
+      leftEye: state.glyph.leftEye,
+      lightAzimuth: state.lightAzimuth,
+      lightDistance: state.lightDistance,
+      lightElevation: state.lightElevation,
+      linkEyes: state.glyph.linkEyes,
+      mouth: state.glyph.mouth,
+      rightEye: state.glyph.rightEye,
+      selectedPaletteId: state.paletteId,
+      showAvatarShadow: state.showAvatarShadow,
+      showFrameShadow: state.showFrameShadow,
+      showLight: state.showLight,
+      showOutline: state.showOutline,
+      showShadow: state.showShadow,
+      viewState: state.viewState
+    }
+  }
   if (!params.has('template')) return config
 
   const preset = parseAvatarEntityPreset(params.get('template'))
@@ -593,7 +639,9 @@ function App({
     const y = Math.sin(direction) * frameShadowStyle.distance
     return `${x.toFixed(2)}px ${
       y.toFixed(2)
-    }px ${frameShadowStyle.softness}px color-mix(in srgb, ${selectedPalette.shadow} ${frameShadowStyle.opacity}%, transparent)`
+    }px ${frameShadowStyle.softness}px color-mix(in srgb, ${
+      frameShadowStyle.color ?? selectedPalette.shadow
+    } ${frameShadowStyle.opacity}%, transparent)`
   }, [frameShadowStyle, selectedPalette.shadow, showFrameShadow])
   const previewEmoticon = `${leftEye}${mouth}${rightEye}`
   const visiblePalettes = useMemo(() => {
@@ -662,7 +710,7 @@ function App({
     lightAzimuth,
     lightDistance,
     lightElevation,
-    paletteId: selectedPalette.id,
+    paletteId: selectedPaletteId,
     showAvatarShadow,
     showFrameShadow,
     showLight,
@@ -695,7 +743,7 @@ function App({
     resolvedFaceShadowStyle,
     resolvedFaceStyle,
     rightEye,
-    selectedPalette.id,
+    selectedPaletteId,
     showAvatarShadow,
     showFrameShadow,
     showLight,
@@ -814,6 +862,12 @@ function App({
     params.set('eyeRound', String(resolvedFaceStyle.eyeRoundness))
     params.set('eyeW', String(resolvedFaceStyle.width))
     params.set('eyeH', String(resolvedFaceStyle.height))
+    if (resolvedFaceStyle.leftEyeHeight != null) {
+      params.set('eyeLeftH', String(resolvedFaceStyle.leftEyeHeight))
+    }
+    if (resolvedFaceStyle.rightEyeHeight != null) {
+      params.set('eyeRightH', String(resolvedFaceStyle.rightEyeHeight))
+    }
     params.set('eyeGap', String(resolvedFaceStyle.gap))
     params.set('eyeRot', String(resolvedFaceStyle.rotation))
     params.set('eyeLeftRot', String(resolvedFaceStyle.leftEyeRotation))
@@ -840,6 +894,9 @@ function App({
     params.set('shadowDist', String(resolvedFaceShadowStyle.distance))
     params.set('shadowOpacity', String(resolvedFaceShadowStyle.opacity))
     params.set('shadowSoft', String(resolvedFaceShadowStyle.softness))
+    if (resolvedFaceShadowStyle.color != null) {
+      params.set('shadowColor', resolvedFaceShadowStyle.color)
+    }
     params.set('avatarShadow', showAvatarShadow ? '1' : '0')
     params.set('avatarShadowColor', avatarShadowStyle.color ?? DEFAULT_AVATAR_SHADOW_STYLE.color ?? '#000000')
     params.set('avatarShadowDir', String(avatarShadowStyle.direction))
@@ -855,6 +912,7 @@ function App({
     params.set('frameShadowDist', String(frameShadowStyle.distance))
     params.set('frameShadowOpacity', String(frameShadowStyle.opacity))
     params.set('frameShadowSoft', String(frameShadowStyle.softness))
+    if (frameShadowStyle.color != null) params.set('frameShadowColor', frameShadowStyle.color)
     params.set('gridDensity', String(gridDensity))
     if (entityPreset === 'custom') {
       params.delete('entity')
@@ -1711,7 +1769,7 @@ function App({
       lightAzimuth,
       lightDistance,
       lightElevation,
-      paletteId: selectedPalette.id,
+      paletteId: selectedPaletteId,
       scale: avatarViewState.scale,
       showLight,
       showOutline,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties } from 'react'
 
 import { AVATAR_PALETTES, AVATAR_PRESETS, getAvatarPalette, isSupportedAvatarEmoticon } from '@oneworks/avatar'
 import type { AvatarBackgroundStyle } from '@oneworks/avatar'
+import type { AvatarAnimationLibrary, AvatarDefinition } from '@oneworks/avatar-core'
 
 import { AnimationPanel } from './AnimationPanel'
 import { AvatarControls } from './AvatarControls'
@@ -84,6 +85,11 @@ import {
 import type { SavedAvatarPreset } from './savedAvatarPresets'
 import { LAST_EDITOR_QUERY_STORAGE_KEY } from './avatarHome'
 import { createAvatarGif } from './avatarGifExport'
+import {
+  avatarDefinitionToSearchParams,
+  createAvatarDefinition,
+  flattenAvatarAnimationLibraries
+} from './avatarDefinition'
 
 const INITIAL_EMOTICON = AVATAR_PRESETS[0]?.emoticon ?? '0w0'
 const INITIAL_PARTS = Array.from(INITIAL_EMOTICON)
@@ -122,7 +128,11 @@ const AVATAR_GITHUB_URL = 'https://github.com/oneworks-ai/avatar'
 type SavePresetState = 'error' | 'idle' | 'saved' | 'saving'
 type GifExportState = 'error' | 'exporting' | 'idle'
 type AvatarTheme = 'dark' | 'light'
-type AvatarAnimationSelectionKey = 'shared' | `preset:${AvatarAnimationPreset['id']}` | `saved:${string}`
+type AvatarAnimationSelectionKey =
+  | 'shared'
+  | `preset:${AvatarAnimationPreset['id']}`
+  | `public:${string}`
+  | `saved:${string}`
 
 interface AvatarQueryConfig {
   readonly animationOpen: boolean
@@ -404,8 +414,10 @@ const parseQueryConfig = (params: URLSearchParams): AvatarQueryConfig => {
   }
 }
 
-const getInitialQueryConfig = () => {
-  const params = typeof window === 'undefined' ? new URLSearchParams() : new URLSearchParams(window.location.search)
+const getInitialQueryConfig = (definition?: AvatarDefinition) => {
+  const params = definition == null
+    ? typeof window === 'undefined' ? new URLSearchParams() : new URLSearchParams(window.location.search)
+    : avatarDefinitionToSearchParams(definition)
   const config = parseQueryConfig(params)
   if (!params.has('template')) return config
 
@@ -458,20 +470,34 @@ const waitForAvatarExportSvg = async (container: Element | null) => {
   return null
 }
 
-interface AppProps {
+export interface AppProps {
+  readonly animationLibraries?: readonly AvatarAnimationLibrary[]
+  readonly definition?: AvatarDefinition
+  readonly embedded?: boolean
+  readonly onDefinitionChange?: (definition: AvatarDefinition) => void
   readonly onHome?: () => void
+  readonly theme?: 'dark' | 'light' | 'system'
 }
 
-function App({ onHome }: AppProps) {
+function App({
+  animationLibraries = [],
+  definition,
+  embedded = false,
+  onDefinitionChange,
+  onHome,
+  theme = 'system'
+}: AppProps) {
   const { t } = useAvatarLocale()
-  const [initialConfig] = useState(getInitialQueryConfig)
+  const [initialConfig] = useState(() => getInitialQueryConfig(definition))
   const [activeTab, setActiveTab] = useState<AvatarControlTab>('build')
   const [controlsCollapsed, setControlsCollapsed] = useState(initialConfig.controlsCollapsed)
   const [controlsWidth, setControlsWidth] = useState(DEFAULT_CONTROLS_WIDTH)
   const [systemDark, setSystemDark] = useState(() => {
     return typeof window !== 'undefined' && window.matchMedia(SYSTEM_DARK_MEDIA_QUERY).matches
   })
-  const [themeOverride, setThemeOverride] = useState<AvatarTheme | null>(null)
+  const [themeOverride, setThemeOverride] = useState<AvatarTheme | null>(
+    theme === 'system' ? null : theme
+  )
   const [interactionMode, setInteractionMode] = useState<AvatarInteractionMode>(initialConfig.interactionMode)
   const [avatarViewState, setAvatarViewState] = useState<AvatarViewState>(initialConfig.viewState)
   const [bodyShape, setBodyShape] = useState<AvatarBodyShape>(initialConfig.bodyShape)
@@ -489,7 +515,9 @@ function App({ onHome }: AppProps) {
   })
   const [backgroundStyle, setBackgroundStyle] = useState<AvatarBackgroundStyle>(initialConfig.backgroundStyle)
   const [faceStyle, setFaceStyle] = useState<AvatarFaceStyle>(initialConfig.faceStyle)
-  const [avatarColorGrade, setAvatarColorGrade] = useState<AvatarColorGrade>(DEFAULT_AVATAR_COLOR_GRADE)
+  const [avatarColorGrade, setAvatarColorGrade] = useState<AvatarColorGrade>(
+    definition?.scene.effects.colorGrade ?? DEFAULT_AVATAR_COLOR_GRADE
+  )
   const [faceShadowStyle, setFaceShadowStyle] = useState<AvatarFaceShadowStyle>(initialConfig.faceShadowStyle)
   const [avatarShadowStyle, setAvatarShadowStyle] = useState<AvatarDropShadowStyle>(initialConfig.avatarShadowStyle)
   const [avatarOutlineStyle, setAvatarOutlineStyle] = useState<AvatarOutlineStyle>(initialConfig.avatarOutlineStyle)
@@ -594,6 +622,120 @@ function App({ onHome }: AppProps) {
     animationStartFrameIndex,
     selectedAnimationKey
   ])
+  const currentDocumentAnimation = useMemo<SavedAvatarAnimation | null>(() => {
+    if (animationKeyframes.length < 2) return null
+    return {
+      createdAt: 0,
+      id: 'document',
+      keyframes: animationKeyframes,
+      lockStartPosition: animationLockStartPosition,
+      name: animationName.trim() || 'Untitled animation',
+      playbackMode: animationPlaybackMode,
+      startFrameIndex: Math.min(animationStartFrameIndex, animationKeyframes.length - 1),
+      version: 3
+    }
+  }, [
+    animationKeyframes,
+    animationLockStartPosition,
+    animationName,
+    animationPlaybackMode,
+    animationStartFrameIndex
+  ])
+  const currentDefinition = useMemo(() => createAvatarDefinition({
+    animation: currentDocumentAnimation,
+    avatarOutlineStyle,
+    avatarShadowStyle,
+    backgroundStyle,
+    bodyShape,
+    cameraBackground,
+    cameraFrame,
+    colorGrade: avatarColorGrade,
+    entityParts,
+    entityPreset,
+    exportSize,
+    faceShadowStyle: resolvedFaceShadowStyle,
+    faceStyle: resolvedFaceStyle,
+    frameShadowStyle,
+    glyph: { leftEye, linkEyes, mouth, rightEye },
+    gridDensity,
+    interactionMode,
+    lightAzimuth,
+    lightDistance,
+    lightElevation,
+    paletteId: selectedPalette.id,
+    showAvatarShadow,
+    showFrameShadow,
+    showLight,
+    showOutline,
+    showShadow,
+    viewState: avatarViewState
+  }, definition), [
+    avatarOutlineStyle,
+    avatarShadowStyle,
+    avatarViewState,
+    backgroundStyle,
+    bodyShape,
+    cameraBackground,
+    cameraFrame,
+    avatarColorGrade,
+    currentDocumentAnimation,
+    definition,
+    entityParts,
+    entityPreset,
+    exportSize,
+    frameShadowStyle,
+    gridDensity,
+    interactionMode,
+    leftEye,
+    lightAzimuth,
+    lightDistance,
+    lightElevation,
+    linkEyes,
+    mouth,
+    resolvedFaceShadowStyle,
+    resolvedFaceStyle,
+    rightEye,
+    selectedPalette.id,
+    showAvatarShadow,
+    showFrameShadow,
+    showLight,
+    showOutline,
+    showShadow
+  ])
+  const currentDefinitionFingerprint = useMemo(
+    () => JSON.stringify(currentDefinition),
+    [currentDefinition]
+  )
+  const lastEmittedDefinitionFingerprintRef = useRef(
+    definition == null ? null : JSON.stringify(definition)
+  )
+  const publicAnimationEntries = useMemo(() => flattenAvatarAnimationLibraries(
+    [definition?.animations, ...animationLibraries].filter(
+      (library): library is AvatarAnimationLibrary => library != null
+    ),
+    currentDefinition.scene
+  ), [animationLibraries, currentDefinition.scene, definition?.animations])
+  const publicAnimations = useMemo(
+    () => publicAnimationEntries.map(entry => entry.animation),
+    [publicAnimationEntries]
+  )
+
+  useEffect(() => {
+    if (!embedded || animationPlaying) return
+    if (lastEmittedDefinitionFingerprintRef.current === currentDefinitionFingerprint) return
+    lastEmittedDefinitionFingerprintRef.current = currentDefinitionFingerprint
+    onDefinitionChange?.(currentDefinition)
+  }, [
+    animationPlaying,
+    currentDefinition,
+    currentDefinitionFingerprint,
+    embedded,
+    onDefinitionChange
+  ])
+
+  useEffect(() => {
+    setThemeOverride(theme === 'system' ? null : theme)
+  }, [theme])
 
   useEffect(() => {
     const mediaQuery = window.matchMedia(SYSTEM_DARK_MEDIA_QUERY)
@@ -604,8 +746,9 @@ function App({ onHome }: AppProps) {
   }, [])
 
   useEffect(() => {
+    if (embedded) return
     document.documentElement.classList.toggle('dark', resolvedTheme === 'dark')
-  }, [resolvedTheme])
+  }, [embedded, resolvedTheme])
 
   useEffect(() => {
     const stage = stageRef.current
@@ -627,6 +770,7 @@ function App({ onHome }: AppProps) {
   }, [])
 
   useEffect(() => {
+    if (embedded) return
     const params = new URLSearchParams(window.location.search)
     params.set('sidebar', controlsCollapsed ? '0' : '1')
     params.set('animationPanel', animationOpen ? '1' : '0')
@@ -645,9 +789,10 @@ function App({ onHome }: AppProps) {
     const nextUrl = new URL(window.location.href)
     nextUrl.search = params.toString()
     window.history.replaceState(null, '', nextUrl)
-  }, [animationOpen, controlsCollapsed, selectedAnimationKey, sharedAnimationQuery])
+  }, [animationOpen, controlsCollapsed, embedded, selectedAnimationKey, sharedAnimationQuery])
 
   useEffect(() => {
+    if (embedded) return
     if (animationPlaying) return
     const params = new URLSearchParams()
     params.set('face', previewEmoticon)
@@ -763,6 +908,7 @@ function App({ onHome }: AppProps) {
     cameraFrame,
     cameraMode,
     controlsCollapsed,
+    embedded,
     entityParts,
     entityPreset,
     exportSize,
@@ -787,6 +933,7 @@ function App({ onHome }: AppProps) {
   ])
 
   useEffect(() => {
+    if (embedded) return
     const handleUndo = (event: globalThis.KeyboardEvent) => {
       if (!(event.metaKey || event.ctrlKey) || event.shiftKey || event.key.toLowerCase() !== 'z' || event.isComposing) {
         return
@@ -861,9 +1008,10 @@ function App({ onHome }: AppProps) {
       window.removeEventListener('keydown', handleUndo)
       window.clearTimeout(undoGroupTimerRef.current)
     }
-  }, [])
+  }, [embedded])
 
   useEffect(() => {
+    if (embedded) return
     if (selectedSavedPresetId == null) return
     const selectedPreset = savedPresets.find(preset => preset.id === selectedSavedPresetId)
     if (selectedPreset != null && selectedPreset.query !== window.location.search) {
@@ -885,6 +1033,7 @@ function App({ onHome }: AppProps) {
     faceStyle,
     frameShadowStyle,
     gridDensity,
+    embedded,
     interactionMode,
     lightAzimuth,
     lightDistance,
@@ -1104,7 +1253,9 @@ function App({ onHome }: AppProps) {
       const preset: SavedAvatarPreset = {
         createdAt: Date.now(),
         id: globalThis.crypto?.randomUUID?.() ?? `preset-${Date.now()}`,
-        query: window.location.search,
+        query: embedded
+          ? `?${avatarDefinitionToSearchParams(currentDefinition).toString()}`
+          : window.location.search,
         screenshot,
         version: 1
       }
@@ -1352,6 +1503,30 @@ function App({ onHome }: AppProps) {
     const firstKeyframe = animation.keyframes[animation.startFrameIndex]
     if (firstKeyframe != null && animation.lockStartPosition) applyAnimationKeyframe(firstKeyframe)
     setAnimationDraftSource('saved')
+    requestAnimationThumbnailCapture(animation.keyframes)
+    playAnimation(animation.keyframes, {
+      lockStartPosition: animation.lockStartPosition,
+      mode: animation.playbackMode,
+      startFrameIndex: animation.startFrameIndex
+    })
+    return true
+  }
+
+  const handlePublicAnimationSelect = (animation: SavedAvatarAnimation) => {
+    stopAnimationPlayback()
+    setAnimationOpen(true)
+    setAnimationPlaybackMode(animation.playbackMode)
+    setAnimationKeyframes(animation.keyframes)
+    setAnimationName(animation.name)
+    setAnimationStartFrameIndex(animation.startFrameIndex)
+    setAnimationLockStartPosition(animation.lockStartPosition)
+    setEditingSavedAnimationId(null)
+    setSelectedAnimationKey(animation.id as AvatarAnimationSelectionKey)
+    setActiveAnimationKeyframe(animation.keyframes.length > 0 ? animation.startFrameIndex : null)
+    setSelectedAnimationKeyframe(null)
+    const firstKeyframe = animation.keyframes[animation.startFrameIndex]
+    if (firstKeyframe != null && animation.lockStartPosition) applyAnimationKeyframe(firstKeyframe)
+    setAnimationDraftSource('builtin')
     requestAnimationThumbnailCapture(animation.keyframes)
     playAnimation(animation.keyframes, {
       lockStartPosition: animation.lockStartPosition,
@@ -1732,7 +1907,10 @@ function App({ onHome }: AppProps) {
   )
 
   return (
-    <main className='avatar-app'>
+    <main
+      className={`avatar-app${embedded && resolvedTheme === 'dark' ? ' dark' : ''}`}
+      data-embedded={embedded ? 'true' : 'false'}
+    >
       <section
         className='avatar-app__workspace'
         data-animation-open={animationOpen}
@@ -2034,11 +2212,13 @@ function App({ onHome }: AppProps) {
               }}
               onPlaybackModeChange={handleAnimationPlaybackModeChange}
               onPresetSelect={handlePresetAnimationSelect}
+              onPublicAnimationSelect={handlePublicAnimationSelect}
               onSavedAnimationRemove={handleSavedAnimationRemove}
               onSavedAnimationSelect={handleSavedAnimationSelect}
               onSave={handleSaveAnimation}
               onStop={stopAnimationPlayback}
               playbackMode={animationPlaybackMode}
+              publicAnimations={publicAnimations}
               renderKeyframePreview={renderAnimationKeyframePreview}
               renderPresetPreview={renderAnimationPresetPreview}
               requiresReplacementConfirmation={shouldConfirmAnimationReplacement(

--- a/src/InteractiveAvatar.tsx
+++ b/src/InteractiveAvatar.tsx
@@ -443,7 +443,7 @@ function EntityPresetBody({
                   key={`shadow-${eye.id}`}
                   d={eye.path}
                   transform={faceShadowTransform(eye.depth)}
-                  fill={facePart.shadowColor}
+                  fill={shadowStyle.color ?? facePart.shadowColor}
                   filter={shadowStyle.softness > 0 ? `url(#${idPrefix}-entity-face-shadow)` : undefined}
                   opacity={shadowStyle.opacity / 100 * eye.depth ** 2}
                 />
@@ -459,7 +459,7 @@ function EntityPresetBody({
                       <path
                         d={face.nose.path}
                         transform={faceShadowTransform(face.nose.depth)}
-                        fill={facePart.shadowColor}
+                        fill={shadowStyle.color ?? facePart.shadowColor}
                         filter={shadowStyle.softness > 0 ? `url(#${idPrefix}-entity-face-shadow)` : undefined}
                         opacity={shadowStyle.opacity / 100 * face.nose.depth ** 2}
                       />
@@ -477,7 +477,7 @@ function EntityPresetBody({
                       <path
                         d={face.mouth.path}
                         transform={faceShadowTransform(face.mouth.depth)}
-                        fill={facePart.shadowColor}
+                        fill={shadowStyle.color ?? facePart.shadowColor}
                         filter={shadowStyle.softness > 0 ? `url(#${idPrefix}-entity-face-shadow)` : undefined}
                         opacity={shadowStyle.opacity / 100 * face.mouth.depth ** 2}
                       />
@@ -792,6 +792,7 @@ function InteractiveAvatarComponent({
   const surfaceHighlight = applyAvatarColorGrade(palette.gradient[0], colorGrade)
   const surfaceShadow = applyAvatarColorGrade(palette.shadow, colorGrade)
   const surfaceForeground = palette.foreground
+  const faceShadowColor = shadowStyle.color ?? surfaceShadow
   const shadowDirection = shadowStyle.direction * Math.PI / 180
   const getFaceShadowTransform = (surfaceDepth: number) => {
     const projectedDistance = shadowStyle.distance * surfaceDepth
@@ -1095,7 +1096,7 @@ function InteractiveAvatarComponent({
                         key={`shadow-${eye.id}`}
                         d={eye.path}
                         transform={getFaceShadowTransform(eye.depth)}
-                        fill={surfaceShadow}
+                        fill={faceShadowColor}
                         filter={shadowFilter}
                         opacity={getFaceShadowOpacity(eye.depth)}
                       />
@@ -1125,7 +1126,7 @@ function InteractiveAvatarComponent({
                               <path
                                 d={part.path}
                                 transform={getFaceShadowTransform(part.depth)}
-                                fill={surfaceShadow}
+                                fill={faceShadowColor}
                                 filter={shadowFilter}
                                 opacity={getFaceShadowOpacity(part.depth)}
                               />

--- a/src/avatarDefinition.ts
+++ b/src/avatarDefinition.ts
@@ -1,0 +1,300 @@
+import {
+  AVATAR_DEFINITION_SCHEMA,
+  AVATAR_DEFINITION_VERSION,
+  applyAvatarScenePatch
+} from '@oneworks/avatar-core'
+import type {
+  AvatarAnimationClip,
+  AvatarAnimationLibrary,
+  AvatarDefinition,
+  AvatarScene
+} from '@oneworks/avatar-core'
+import type { AvatarBackgroundStyle } from '@oneworks/avatar'
+
+import type { ExportSize } from './ExportToolbar'
+import type {
+  AvatarDropShadowStyle,
+  AvatarInteractionMode,
+  AvatarOutlineStyle,
+  AvatarViewState
+} from './InteractiveAvatar'
+import type {
+  AvatarAnimationKeyframe,
+  AvatarAnimationPlaybackMode,
+  SavedAvatarAnimation
+} from './avatarAnimations'
+import type { AvatarColorGrade } from './avatarColorGrade'
+import { serializeAvatarEntityParts } from './avatarEntityPresets'
+import type { AvatarEntityPart, AvatarEntityPreset } from './avatarEntityPresets'
+import type { AvatarBodyShape, AvatarFaceShadowStyle, AvatarFaceStyle } from './avatarGeometry'
+import type { AvatarCameraFrame } from './AvatarControls'
+
+export interface AvatarDefinitionState {
+  readonly animation?: SavedAvatarAnimation | null
+  readonly avatarOutlineStyle: AvatarOutlineStyle
+  readonly avatarShadowStyle: AvatarDropShadowStyle
+  readonly backgroundStyle: AvatarBackgroundStyle
+  readonly bodyShape: AvatarBodyShape
+  readonly cameraBackground: string
+  readonly cameraFrame: AvatarCameraFrame
+  readonly colorGrade: AvatarColorGrade
+  readonly entityParts: readonly AvatarEntityPart[]
+  readonly entityPreset: AvatarEntityPreset
+  readonly exportSize: ExportSize
+  readonly faceShadowStyle: AvatarFaceShadowStyle
+  readonly faceStyle: AvatarFaceStyle
+  readonly frameShadowStyle: AvatarDropShadowStyle
+  readonly glyph: {
+    readonly leftEye: string
+    readonly linkEyes: boolean
+    readonly mouth: string
+    readonly rightEye: string
+  }
+  readonly gridDensity: number
+  readonly interactionMode: AvatarInteractionMode
+  readonly lightAzimuth: number
+  readonly lightDistance: number
+  readonly lightElevation: number
+  readonly paletteId: string
+  readonly showAvatarShadow: boolean
+  readonly showFrameShadow: boolean
+  readonly showLight: boolean
+  readonly showOutline: boolean
+  readonly showShadow: boolean
+  readonly viewState: AvatarViewState
+}
+
+const toPublicPart = (part: AvatarEntityPart) => ({ ...part })
+
+export const savedAvatarAnimationToClip = (animation: SavedAvatarAnimation): AvatarAnimationClip => {
+  let atMs = 0
+  const keyframes = animation.keyframes.map((keyframe, index) => {
+    if (index > 0) atMs += keyframe.durationMs
+    return {
+      atMs,
+      easing: keyframe.easing,
+      patch: {
+        colorGrade: keyframe.colorGrade,
+        face: keyframe.faceStyle,
+        view: {
+          pitch: keyframe.pitch,
+          positionX: keyframe.positionX,
+          positionY: keyframe.positionY,
+          yaw: keyframe.yaw
+        }
+      }
+    }
+  })
+  const loopDuration = animation.playbackMode === 'loop'
+    ? animation.keyframes[0]?.durationMs ?? 0
+    : 0
+  return {
+    anchor: animation.lockStartPosition ? 'absolute' : 'relative',
+    durationMs: Math.max(atMs + loopDuration, 1),
+    keyframes,
+    label: animation.name,
+    playback: animation.playbackMode
+  }
+}
+
+const createEmbeddedAnimationLibrary = (animation: SavedAvatarAnimation): AvatarAnimationLibrary => ({
+  groups: {
+    document: {
+      clips: { animation: savedAvatarAnimationToClip(animation) },
+      defaultClip: 'animation',
+      label: 'Document animations'
+    }
+  },
+  id: 'document',
+  label: 'Document animations'
+})
+
+export const createAvatarDefinition = (
+  state: AvatarDefinitionState,
+  previous?: AvatarDefinition
+): AvatarDefinition => ({
+  animations: state.animation == null
+    ? previous?.animations
+    : createEmbeddedAnimationLibrary(state.animation),
+  metadata: previous?.metadata,
+  scene: {
+    appearance: {
+      backgroundStyle: state.backgroundStyle,
+      bodyShape: state.bodyShape,
+      paletteId: state.paletteId
+    },
+    camera: {
+      background: state.cameraBackground,
+      frame: state.cameraFrame,
+      frameShadow: state.frameShadowStyle,
+      showFrameShadow: state.showFrameShadow,
+      size: state.exportSize
+    },
+    effects: {
+      avatarShadow: state.avatarShadowStyle,
+      colorGrade: state.colorGrade,
+      faceShadow: state.faceShadowStyle,
+      outline: state.avatarOutlineStyle,
+      showAvatarShadow: state.showAvatarShadow,
+      showFaceShadow: state.showShadow,
+      showOutline: state.showOutline
+    },
+    entity: {
+      parts: state.entityParts.map(toPublicPart),
+      preset: state.entityPreset
+    },
+    face: state.faceStyle,
+    glyph: state.glyph,
+    interactionMode: state.interactionMode,
+    lighting: {
+      azimuth: state.lightAzimuth,
+      distance: state.lightDistance,
+      elevation: state.lightElevation,
+      enabled: state.showLight,
+      gridDensity: state.gridDensity
+    },
+    view: state.viewState
+  },
+  schema: AVATAR_DEFINITION_SCHEMA,
+  version: AVATAR_DEFINITION_VERSION
+})
+
+const setBoolean = (params: URLSearchParams, key: string, value: boolean) => {
+  params.set(key, value ? '1' : '0')
+}
+
+export const avatarDefinitionToSearchParams = (definition: AvatarDefinition) => {
+  const { scene } = definition
+  const params = new URLSearchParams()
+  params.set('face', `${scene.glyph.leftEye}${scene.glyph.mouth}${scene.glyph.rightEye}`)
+  params.set('palette', scene.appearance.paletteId)
+  params.set('bg', scene.appearance.backgroundStyle)
+  params.set('shape', scene.appearance.bodyShape)
+  params.set('mode', scene.interactionMode)
+  params.set('yaw', String(scene.view.yaw))
+  params.set('pitch', String(scene.view.pitch))
+  params.set('roll', String(scene.view.roll))
+  params.set('positionX', String(scene.view.positionX))
+  params.set('positionY', String(scene.view.positionY))
+  params.set('scale', String(scene.view.scale))
+  params.set('camera', '1')
+  params.set('cameraBg', scene.camera.background)
+  params.set('cameraFrame', scene.camera.frame)
+  setBoolean(params, 'eyes', scene.glyph.linkEyes)
+  params.set('eyeShape', scene.face.eyeShape)
+  params.set('eyeRound', String(scene.face.eyeRoundness))
+  params.set('eyeW', String(scene.face.width))
+  params.set('eyeH', String(scene.face.height))
+  params.set('eyeGap', String(scene.face.gap))
+  params.set('eyeRot', String(scene.face.rotation))
+  params.set('eyeLeftRot', String(scene.face.leftEyeRotation))
+  params.set('eyeRightRot', String(scene.face.rightEyeRotation))
+  setBoolean(params, 'nose', scene.face.noseEnabled)
+  params.set('noseShape', scene.face.noseShape)
+  params.set('noseW', String(scene.face.noseWidth))
+  params.set('noseH', String(scene.face.noseHeight))
+  params.set('noseY', String(scene.face.noseY))
+  params.set('noseRot', String(scene.face.noseRotation))
+  setBoolean(params, 'mouth', scene.face.mouthEnabled)
+  params.set('mouthShape', scene.face.mouthShape)
+  params.set('mouthCurve', String(scene.face.mouthCurve))
+  params.set('mouthW', String(scene.face.mouthWidth))
+  params.set('mouthH', String(scene.face.mouthHeight))
+  params.set('mouthY', String(scene.face.mouthY))
+  params.set('mouthRot', String(scene.face.mouthRotation))
+  setBoolean(params, 'light', scene.lighting.enabled)
+  params.set('lightAz', String(scene.lighting.azimuth))
+  params.set('lightEl', String(scene.lighting.elevation))
+  params.set('lightDist', String(scene.lighting.distance))
+  setBoolean(params, 'shadow', scene.effects.showFaceShadow)
+  params.set('shadowDir', String(scene.effects.faceShadow.direction))
+  params.set('shadowDist', String(scene.effects.faceShadow.distance))
+  params.set('shadowOpacity', String(scene.effects.faceShadow.opacity))
+  params.set('shadowSoft', String(scene.effects.faceShadow.softness))
+  setBoolean(params, 'avatarShadow', scene.effects.showAvatarShadow)
+  params.set('avatarShadowColor', scene.effects.avatarShadow.color ?? '#000000')
+  params.set('avatarShadowDir', String(scene.effects.avatarShadow.direction))
+  params.set('avatarShadowDist', String(scene.effects.avatarShadow.distance))
+  params.set('avatarShadowOpacity', String(scene.effects.avatarShadow.opacity))
+  params.set('avatarShadowSoft', String(scene.effects.avatarShadow.softness))
+  setBoolean(params, 'outline', scene.effects.showOutline)
+  params.set('outlineColor', scene.effects.outline.color)
+  params.set('outlineWidth', String(scene.effects.outline.width))
+  params.set('outlineOpacity', String(scene.effects.outline.opacity))
+  setBoolean(params, 'frameShadow', scene.camera.showFrameShadow)
+  params.set('frameShadowDir', String(scene.camera.frameShadow.direction))
+  params.set('frameShadowDist', String(scene.camera.frameShadow.distance))
+  params.set('frameShadowOpacity', String(scene.camera.frameShadow.opacity))
+  params.set('frameShadowSoft', String(scene.camera.frameShadow.softness))
+  params.set('gridDensity', String(scene.lighting.gridDensity))
+  params.set('entity', scene.entity.preset)
+  if (scene.entity.parts.length > 0) {
+    params.set('entityParts', serializeAvatarEntityParts(scene.entity.parts as readonly AvatarEntityPart[]))
+  }
+  params.set('size', String(scene.camera.size))
+  params.set('sidebar', '1')
+  params.set('animationPanel', '0')
+  return params
+}
+
+export const avatarAnimationClipToSavedAnimation = (
+  id: string,
+  clip: AvatarAnimationClip,
+  scene: AvatarScene
+): SavedAvatarAnimation => {
+  const ordered = [...clip.keyframes].sort((a, b) => a.atMs - b.atMs)
+  const keyframes: AvatarAnimationKeyframe[] = ordered.map((frame, index) => {
+    const resolved = applyAvatarScenePatch(scene, frame.patch)
+    const previous = ordered[index - 1]
+    const durationMs = index === 0
+      ? clip.playback === 'loop'
+        ? Math.max(clip.durationMs - (ordered.at(-1)?.atMs ?? 0), 100)
+        : 100
+      : Math.max(frame.atMs - (previous?.atMs ?? 0), 100)
+    return {
+      colorGrade: resolved.effects.colorGrade as AvatarColorGrade,
+      durationMs,
+      easing: frame.easing ?? 'linear',
+      faceStyle: resolved.face as AvatarFaceStyle,
+      pitch: resolved.view.pitch,
+      positionX: resolved.view.positionX,
+      positionY: resolved.view.positionY,
+      yaw: resolved.view.yaw
+    }
+  })
+  return {
+    createdAt: 0,
+    id,
+    keyframes,
+    lockStartPosition: clip.anchor === 'absolute',
+    name: clip.label ?? id,
+    playbackMode: clip.playback as AvatarAnimationPlaybackMode,
+    startFrameIndex: 0,
+    version: 3
+  }
+}
+
+export interface PublicAvatarAnimationEntry {
+  readonly animation: SavedAvatarAnimation
+  readonly clipId: string
+  readonly groupId: string
+  readonly libraryId: string
+}
+
+export const flattenAvatarAnimationLibraries = (
+  libraries: readonly AvatarAnimationLibrary[],
+  scene: AvatarScene
+): readonly PublicAvatarAnimationEntry[] => libraries.flatMap(library => (
+  Object.entries(library.groups).flatMap(([groupId, group]) => (
+    Object.entries(group.clips).map(([clipId, clip]) => ({
+      animation: avatarAnimationClipToSavedAnimation(
+        `public:${library.id}:${groupId}:${clipId}`,
+        clip,
+        scene
+      ),
+      clipId,
+      groupId,
+      libraryId: library.id
+    }))
+  ))
+))

--- a/src/avatarDefinition.ts
+++ b/src/avatarDefinition.ts
@@ -2,7 +2,8 @@ import {
   AVATAR_DEFINITION_SCHEMA,
   AVATAR_DEFINITION_VERSION,
   anchorAvatarAnimationClip,
-  applyAvatarScenePatch
+  applyAvatarScenePatch,
+  parseAvatarAnimationClip
 } from '@oneworks/avatar-core'
 import type {
   AvatarAnimationClip,
@@ -243,11 +244,12 @@ export const avatarAnimationClipToSavedAnimation = (
   clip: AvatarAnimationClip,
   scene: AvatarScene
 ): SavedAvatarAnimation => {
+  const parsedClip = parseAvatarAnimationClip(clip)
   const resolvedClip = anchorAvatarAnimationClip({
     scene,
     schema: AVATAR_DEFINITION_SCHEMA,
     version: AVATAR_DEFINITION_VERSION
-  }, clip)
+  }, parsedClip)
   const ordered = [...resolvedClip.keyframes].sort((a, b) => a.atMs - b.atMs)
   const withBase = ordered[0]?.atMs != null && ordered[0].atMs > 0
     ? [{ atMs: 0, easing: ordered[0].easing, patch: {} }, ...ordered]

--- a/src/avatarDefinition.ts
+++ b/src/avatarDefinition.ts
@@ -243,12 +243,15 @@ export const avatarAnimationClipToSavedAnimation = (
   scene: AvatarScene
 ): SavedAvatarAnimation => {
   const ordered = [...clip.keyframes].sort((a, b) => a.atMs - b.atMs)
-  const keyframes: AvatarAnimationKeyframe[] = ordered.map((frame, index) => {
+  const timeline = ordered[0]?.atMs != null && ordered[0].atMs > 0
+    ? [{ atMs: 0, easing: ordered[0].easing, patch: {} }, ...ordered]
+    : ordered
+  const keyframes: AvatarAnimationKeyframe[] = timeline.map((frame, index) => {
     const resolved = applyAvatarScenePatch(scene, frame.patch)
-    const previous = ordered[index - 1]
+    const previous = timeline[index - 1]
     const durationMs = index === 0
       ? clip.playback === 'loop'
-        ? Math.max(clip.durationMs - (ordered.at(-1)?.atMs ?? 0), 100)
+        ? Math.max(clip.durationMs - (timeline.at(-1)?.atMs ?? 0), 100)
         : 100
       : Math.max(frame.atMs - (previous?.atMs ?? 0), 100)
     return {

--- a/src/avatarDefinition.ts
+++ b/src/avatarDefinition.ts
@@ -1,6 +1,7 @@
 import {
   AVATAR_DEFINITION_SCHEMA,
   AVATAR_DEFINITION_VERSION,
+  anchorAvatarAnimationClip,
   applyAvatarScenePatch
 } from '@oneworks/avatar-core'
 import type {
@@ -242,16 +243,25 @@ export const avatarAnimationClipToSavedAnimation = (
   clip: AvatarAnimationClip,
   scene: AvatarScene
 ): SavedAvatarAnimation => {
-  const ordered = [...clip.keyframes].sort((a, b) => a.atMs - b.atMs)
-  const timeline = ordered[0]?.atMs != null && ordered[0].atMs > 0
+  const resolvedClip = anchorAvatarAnimationClip({
+    scene,
+    schema: AVATAR_DEFINITION_SCHEMA,
+    version: AVATAR_DEFINITION_VERSION
+  }, clip)
+  const ordered = [...resolvedClip.keyframes].sort((a, b) => a.atMs - b.atMs)
+  const withBase = ordered[0]?.atMs != null && ordered[0].atMs > 0
     ? [{ atMs: 0, easing: ordered[0].easing, patch: {} }, ...ordered]
     : ordered
+  const last = withBase.at(-1)
+  const timeline = resolvedClip.playback === 'once' && last != null && last.atMs < resolvedClip.durationMs
+    ? [...withBase, { atMs: resolvedClip.durationMs, easing: last.easing, patch: last.patch }]
+    : withBase
   const keyframes: AvatarAnimationKeyframe[] = timeline.map((frame, index) => {
     const resolved = applyAvatarScenePatch(scene, frame.patch)
     const previous = timeline[index - 1]
     const durationMs = index === 0
-      ? clip.playback === 'loop'
-        ? Math.max(clip.durationMs - (timeline.at(-1)?.atMs ?? 0), 100)
+      ? resolvedClip.playback === 'loop'
+        ? Math.max(resolvedClip.durationMs - (timeline.at(-1)?.atMs ?? 0), 100)
         : 100
       : Math.max(frame.atMs - (previous?.atMs ?? 0), 100)
     return {
@@ -269,9 +279,9 @@ export const avatarAnimationClipToSavedAnimation = (
     createdAt: 0,
     id,
     keyframes,
-    lockStartPosition: clip.anchor === 'absolute',
-    name: clip.label ?? id,
-    playbackMode: clip.playback as AvatarAnimationPlaybackMode,
+    lockStartPosition: resolvedClip.anchor === 'absolute',
+    name: resolvedClip.label ?? id,
+    playbackMode: resolvedClip.playback as AvatarAnimationPlaybackMode,
     startFrameIndex: 0,
     version: 3
   }

--- a/src/avatarDefinition.ts
+++ b/src/avatarDefinition.ts
@@ -68,6 +68,39 @@ export interface AvatarDefinitionState {
 
 const toPublicPart = (part: AvatarEntityPart) => ({ ...part })
 
+export const avatarDefinitionToState = (definition: AvatarDefinition): AvatarDefinitionState => {
+  const { scene } = definition
+  return {
+    animation: undefined,
+    avatarOutlineStyle: scene.effects.outline,
+    avatarShadowStyle: scene.effects.avatarShadow,
+    backgroundStyle: scene.appearance.backgroundStyle,
+    bodyShape: scene.appearance.bodyShape,
+    cameraBackground: scene.camera.background,
+    cameraFrame: scene.camera.frame,
+    colorGrade: scene.effects.colorGrade,
+    entityParts: scene.entity.parts,
+    entityPreset: scene.entity.preset,
+    exportSize: scene.camera.size,
+    faceShadowStyle: scene.effects.faceShadow,
+    faceStyle: scene.face,
+    frameShadowStyle: scene.camera.frameShadow,
+    glyph: scene.glyph,
+    gridDensity: scene.lighting.gridDensity,
+    interactionMode: scene.interactionMode,
+    lightAzimuth: scene.lighting.azimuth,
+    lightDistance: scene.lighting.distance,
+    lightElevation: scene.lighting.elevation,
+    paletteId: scene.appearance.paletteId,
+    showAvatarShadow: scene.effects.showAvatarShadow,
+    showFrameShadow: scene.camera.showFrameShadow,
+    showLight: scene.lighting.enabled,
+    showOutline: scene.effects.showOutline,
+    showShadow: scene.effects.showFaceShadow,
+    viewState: scene.view
+  }
+}
+
 export const savedAvatarAnimationToClip = (animation: SavedAvatarAnimation): AvatarAnimationClip => {
   let atMs = 0
   const keyframes = animation.keyframes.map((keyframe, index) => {
@@ -187,6 +220,8 @@ export const avatarDefinitionToSearchParams = (definition: AvatarDefinition) => 
   params.set('eyeRound', String(scene.face.eyeRoundness))
   params.set('eyeW', String(scene.face.width))
   params.set('eyeH', String(scene.face.height))
+  if (scene.face.leftEyeHeight != null) params.set('eyeLeftH', String(scene.face.leftEyeHeight))
+  if (scene.face.rightEyeHeight != null) params.set('eyeRightH', String(scene.face.rightEyeHeight))
   params.set('eyeGap', String(scene.face.gap))
   params.set('eyeRot', String(scene.face.rotation))
   params.set('eyeLeftRot', String(scene.face.leftEyeRotation))
@@ -213,6 +248,7 @@ export const avatarDefinitionToSearchParams = (definition: AvatarDefinition) => 
   params.set('shadowDist', String(scene.effects.faceShadow.distance))
   params.set('shadowOpacity', String(scene.effects.faceShadow.opacity))
   params.set('shadowSoft', String(scene.effects.faceShadow.softness))
+  if (scene.effects.faceShadow.color != null) params.set('shadowColor', scene.effects.faceShadow.color)
   setBoolean(params, 'avatarShadow', scene.effects.showAvatarShadow)
   params.set('avatarShadowColor', scene.effects.avatarShadow.color ?? '#000000')
   params.set('avatarShadowDir', String(scene.effects.avatarShadow.direction))
@@ -228,6 +264,9 @@ export const avatarDefinitionToSearchParams = (definition: AvatarDefinition) => 
   params.set('frameShadowDist', String(scene.camera.frameShadow.distance))
   params.set('frameShadowOpacity', String(scene.camera.frameShadow.opacity))
   params.set('frameShadowSoft', String(scene.camera.frameShadow.softness))
+  if (scene.camera.frameShadow.color != null) {
+    params.set('frameShadowColor', scene.camera.frameShadow.color)
+  }
   params.set('gridDensity', String(scene.lighting.gridDensity))
   params.set('entity', scene.entity.preset)
   if (scene.entity.parts.length > 0) {

--- a/src/avatarEntityPresets.ts
+++ b/src/avatarEntityPresets.ts
@@ -500,10 +500,13 @@ export const serializeAvatarEntityParts = (parts: readonly AvatarEntityPart[]) =
   part.roundness ?? 24,
   part.cutAngle ?? 0,
   part.hollow ? 1 : 0,
-  null,
-  null,
+  part.face ? 1 : 0,
+  part.label,
   resolveAvatarEntityPartScaleZ(part),
-  part.topScale ?? null
+  part.topScale ?? null,
+  part.occludedByFace == null ? null : part.occludedByFace ? 1 : 0,
+  part.occlusionAmount ?? null,
+  part.occlusionPole ?? null
 ]))
 
 export const deserializeAvatarEntityParts = (
@@ -511,19 +514,42 @@ export const deserializeAvatarEntityParts = (
   preset: AvatarEntityPreset
 ): AvatarEntityPart[] => {
   const defaults = createAvatarEntityParts(preset)
-  if (value == null || defaults.length === 0) return defaults
+  if (value == null) return defaults
   try {
     const parsed: unknown = JSON.parse(value)
     if (!Array.isArray(parsed)) return defaults
-    const byId = new Map(parsed.filter(Array.isArray).map(item => [item[0], item]))
-    return defaults.map(part => {
-      const item = byId.get(part.id)
-      if (!Array.isArray(item)) return part
+    const defaultsById = new Map(defaults.map(part => [part.id, part]))
+    const parts = parsed.flatMap(item => {
+      if (!Array.isArray(item) || typeof item[0] !== 'string' || item[0].length === 0) return []
+      const fallback = defaultsById.get(item[0])
+      const shape = AVATAR_BODY_SHAPES.includes(item[1] as AvatarBodyShape)
+        ? item[1] as AvatarBodyShape
+        : fallback?.shape
+      const baseColor = isHexColor(item[7]) ? item[7] : fallback?.baseColor
+      const highlightColor = isHexColor(item[8]) ? item[8] : fallback?.highlightColor
+      const shadowColor = isHexColor(item[9]) ? item[9] : fallback?.shadowColor
+      const foregroundColor = isHexColor(item[10]) ? item[10] : fallback?.foregroundColor
+      if (
+        shape == null || baseColor == null || highlightColor == null ||
+        shadowColor == null || foregroundColor == null
+      ) return []
+      const part: AvatarEntityPart = {
+        baseColor,
+        face: item[17] === 1 ? true : item[17] === 0 ? false : fallback?.face ?? false,
+        foregroundColor,
+        highlightColor,
+        id: item[0],
+        label: typeof item[18] === 'string' ? item[18] : fallback?.label ?? item[0],
+        scaleX: finite(item[5], fallback?.scaleX ?? 1, .08, 1.5),
+        scaleY: finite(item[6], fallback?.scaleY ?? 1, .08, 1.5),
+        shadowColor,
+        shape,
+        x: finiteNumber(item[2], fallback?.x ?? 0),
+        y: finiteNumber(item[3], fallback?.y ?? 0),
+        z: finiteNumber(item[4], fallback?.z ?? 0)
+      }
       return {
         ...part,
-        baseColor: isHexColor(item[7]) ? item[7] : part.baseColor,
-        foregroundColor: isHexColor(item[10]) ? item[10] : part.foregroundColor,
-        highlightColor: isHexColor(item[8]) ? item[8] : part.highlightColor,
         hollow: item[16] === 1,
         cutAngle: finiteNumber(item[15], part.cutAngle ?? 0),
         rotationX: finiteNumber(item[11], part.rotationX ?? 0),
@@ -533,14 +559,17 @@ export const deserializeAvatarEntityParts = (
         scaleX: finite(item[5], part.scaleX, .08, 1.5),
         scaleY: finite(item[6], part.scaleY, .08, 1.5),
         scaleZ: finite(item[19], resolveAvatarEntityPartScaleZ(part), .08, 1.5),
-        shadowColor: isHexColor(item[9]) ? item[9] : part.shadowColor,
-        shape: AVATAR_BODY_SHAPES.includes(item[1] as AvatarBodyShape) ? item[1] as AvatarBodyShape : part.shape,
         topScale: finite(item[20], part.topScale ?? .82, .4, 1.2),
-        x: finiteNumber(item[2], part.x),
-        y: finiteNumber(item[3], part.y),
-        z: finiteNumber(item[4], part.z)
+        occludedByFace: item[21] === 1 ? true : item[21] === 0 ? false : fallback?.occludedByFace,
+        occlusionAmount: item[22] == null
+          ? fallback?.occlusionAmount
+          : finite(item[22], fallback?.occlusionAmount ?? 0, 0, 100),
+        occlusionPole: item[23] === 'bottom' || item[23] === 'top'
+          ? item[23]
+          : fallback?.occlusionPole
       }
     })
+    return parts.length === 0 && parsed.length > 0 ? defaults : parts
   } catch {
     return defaults
   }

--- a/src/avatarGeometry.ts
+++ b/src/avatarGeometry.ts
@@ -46,6 +46,7 @@ export const AVATAR_GRID_DENSITY = {
 } as const
 
 export interface AvatarFaceShadowStyle {
+  readonly color?: string
   readonly direction: number
   readonly distance: number
   readonly opacity: number

--- a/src/avatarLocale.tsx
+++ b/src/avatarLocale.tsx
@@ -222,6 +222,10 @@ export function AvatarLocaleProvider({
   const t = useCallback((text: string) => translateAvatarText(locale, text), [locale])
 
   useEffect(() => {
+    if (initialLocale != null) setLocale(initialLocale)
+  }, [initialLocale])
+
+  useEffect(() => {
     if (!persist) return
     document.documentElement.lang = locale
     window.localStorage.setItem(AVATAR_LOCALE_STORAGE_KEY, locale)

--- a/src/avatarLocale.tsx
+++ b/src/avatarLocale.tsx
@@ -209,14 +209,23 @@ interface AvatarLocaleContextValue {
 
 const AvatarLocaleContext = createContext<AvatarLocaleContextValue | null>(null)
 
-export function AvatarLocaleProvider({ children }: { readonly children: ReactNode }) {
-  const [locale, setLocale] = useState<AvatarLocale>(getInitialAvatarLocale)
+export function AvatarLocaleProvider({
+  children,
+  initialLocale,
+  persist = true
+}: {
+  readonly children: ReactNode
+  readonly initialLocale?: AvatarLocale
+  readonly persist?: boolean
+}) {
+  const [locale, setLocale] = useState<AvatarLocale>(() => initialLocale ?? getInitialAvatarLocale())
   const t = useCallback((text: string) => translateAvatarText(locale, text), [locale])
 
   useEffect(() => {
+    if (!persist) return
     document.documentElement.lang = locale
     window.localStorage.setItem(AVATAR_LOCALE_STORAGE_KEY, locale)
-  }, [locale])
+  }, [locale, persist])
 
   const value = useMemo(() => ({ locale, setLocale, t }), [locale, t])
 

--- a/tsconfig.app-source.json
+++ b/tsconfig.app-source.json
@@ -8,6 +8,9 @@
       ],
       "@oneworks/avatar/*": [
         "./app-source/packages/avatar/src/*.ts"
+      ],
+      "@oneworks/avatar-core": [
+        "./packages/core/src/index.ts"
       ]
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "outDir": "./dist-types",
+    "baseUrl": ".",
     "resolveJsonModule": true,
     "rootDir": "./src",
     "skipLibCheck": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,18 @@ export default defineConfig({
     : {
         alias: [
           {
+            find: /^@oneworks\/avatar-core$/,
+            replacement: path.resolve('packages/core/src/index.ts')
+          },
+          {
+            find: /^@oneworks\/avatar-react$/,
+            replacement: path.resolve('packages/react/src/index.tsx')
+          },
+          {
+            find: /^@oneworks\/avatar-react\/style\.css$/,
+            replacement: path.resolve('packages/react/src/style.scss')
+          },
+          {
             find: /^@oneworks\/avatar$/,
             replacement: path.join(appSourcePath, 'packages/avatar/src/index.ts')
           },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+
+import viteConfig from './vite.config'
+
+export default mergeConfig(viteConfig, defineConfig({
+  test: {
+    exclude: ['**/app-source/**', '**/dist/**', '**/node_modules/**']
+  }
+}))


### PR DESCRIPTION
## Change Brief

- Add a stable, versioned 3D Avatar definition and custom animation-group contract.
- Keep the hosted editor and all SDK adapters on the same geometric SVG renderer; no alternate 2D reconstruction.
- Preserve the existing legacy `@oneworks/avatar` 2D package without changing its public API.
- Add framework adapters for React, Vue, Vanilla JavaScript, and opt-in Web Components.
- Expose the full editor as an embeddable component/mount alongside the renderer.
- Keep the hosted share URL as an opaque editor URL; the public definition is the portable runtime source.

## Implementation

- `@oneworks/avatar-core`: versioned scene schema, validation, serialization, animation libraries, references, relative anchoring, interpolation.
- `@oneworks/avatar-react`: `Avatar`, `AvatarEditor`, playback controller, capture API.
- `@oneworks/avatar-web`: `createAvatar`, `createAvatarEditor`, DOM events, and explicit `registerAvatarElements()` with no import-time custom-element registration.
- `@oneworks/avatar-vue`: `OneWorksAvatar` and `OneWorksAvatarEditor` over the same runtime.
- Existing editor accepts external animation libraries and opens selected clips in the real animation timeline.
- Added a live SDK fixture and a clean packed-package consumer smoke test.

## Validation

- [x] `pnpm test` — 58 tests across editor, core runtime, React lifecycle, and custom-element registration
- [x] `pnpm typecheck:sdk`
- [x] `pnpm build`
- [x] `pnpm smoke:sdk` — pack/install/typecheck/build in a clean non-workspace consumer
- [x] `pnpm audit --prod --audit-level high`
- [x] `git diff --check`
- [x] Real IAB fixture: external `Acknowledge` animation appears in the editor and produces live frame changes
- [x] EN/ZH package entry documentation and license files included in every tarball

## Experience Review

- [x] Verified the public renderer and editor use the existing OneWorks 3D renderer and current scene geometry.
- [x] Verified custom animations remain editable in the existing timeline instead of becoming a parallel playback system.
- [x] Verified the embedded editor, dark theme, responsive component sizing, and explicit Web Component registration path.