### PR TITLE
fix: support parent workspace installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@oneworks/avatar": "beta",
-    "@oneworks/avatar-core": "workspace:*",
+    "@oneworks/avatar-core": "link:packages/core",
     "@oneworks/route-layout": "beta",
     "gifenc": "^1.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: beta
         version: 0.1.0-beta.10
       '@oneworks/avatar-core':
-        specifier: workspace:*
+        specifier: link:packages/core
         version: link:packages/core
       '@oneworks/route-layout':
         specifier: beta


### PR DESCRIPTION
## Change Brief

- Keep the private Avatar application root compatible when mounted as the `assets/avatar` workspace project in `oneworks-ai/app`.
- Resolve the local public core through `link:packages/core` instead of requiring the parent workspace to discover the nested Avatar workspace.
- Leave the four publishable SDK packages and their `workspace:*` package-to-package contracts unchanged.

## Validation

- [x] `pnpm install --lockfile-only`
- [x] `pnpm test` — 58/58
- [x] `pnpm typecheck:sdk`
- [x] `pnpm build`
- [x] `pnpm smoke:sdk`
- [x] `git diff --check`

## Experience Review

- [x] Verified the standalone Avatar workspace still builds and packs all four public SDK packages.
- [x] Verified the change is limited to the private application root importer and its lockfile entry.
- [x] Root cause reproduced from the parent app workspace: nested `workspace:*` dependencies are not members of the parent workspace.
