### PR TITLE
ci: publish Avatar SDK with provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,199 @@
+name: Publish Avatar SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        default: true
+        description: Pack and validate without publishing to npm.
+        required: false
+        type: boolean
+      publish_tag:
+        default: rc
+        description: npm dist-tag for the release.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+concurrency:
+  group: avatar-sdk-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: test-pack-validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.publish.outputs.version }}
+
+    steps:
+      - name: Checkout Avatar repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Checkout shared OneWorks sources
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: oneworks-ai/app
+          path: app-source
+          submodules: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.7.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: app-source/.node-version
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test editor and runtime contracts
+        run: pnpm test
+
+      - name: Build and typecheck SDK packages
+        run: pnpm typecheck:sdk
+
+      - name: Test packed packages in a clean consumer
+        run: pnpm smoke:sdk
+
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level high
+
+      - name: Prepare immutable npm tarballs
+        id: publish
+        env:
+          NPM_PUBLISH_TARBALL_DIRECTORY: ${{ runner.temp }}/avatar-sdk-tarballs
+          PUBLISH_TAG: ${{ inputs.publish_tag }}
+        run: node scripts/publish-sdk-packages.mjs --prepare-only
+
+      - name: Upload immutable npm tarballs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: avatar-sdk-${{ steps.publish.outputs.version }}
+          path: ${{ runner.temp }}/avatar-sdk-tarballs
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: oidc-publish-verify
+    needs: validate
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      version: ${{ steps.publish.outputs.version }}
+
+    steps:
+      - name: Checkout validated source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm with Trusted Publishing support
+        run: npm install -g npm@11.15.0
+
+      - name: Download immutable npm tarballs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: avatar-sdk-${{ needs.validate.outputs.version }}
+          path: ${{ runner.temp }}/avatar-sdk-tarballs
+
+      - name: Require protected main for publishing
+        env:
+          TRUSTED_PUBLISHERS: ${{ vars.NPM_TRUSTED_PUBLISHERS }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/main'
+          test "$TRUSTED_PUBLISHERS" = '@oneworks/avatar,@oneworks/avatar-react,@oneworks/avatar-web,@oneworks/avatar-vue|oneworks-ai/avatar|npm-publish.yml|npm-publish|allow:npm-publish|token:none'
+
+      - name: Create tokenless npm configuration
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/avatar-npm-publish.npmrc
+        run: |
+          umask 077
+          printf 'registry=https://registry.npmjs.org/\n' > "$NPM_CONFIG_USERCONFIG"
+
+      - name: Publish and reconcile npm packages
+        id: publish
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/avatar-npm-publish.npmrc
+          NPM_PUBLISH_TARBALL_DIRECTORY: ${{ runner.temp }}/avatar-sdk-tarballs
+          PUBLISH_TAG: ${{ inputs.publish_tag }}
+        run: node scripts/publish-sdk-packages.mjs --publish-prepared
+
+      - name: Remove isolated npm configuration
+        if: ${{ always() }}
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/avatar-npm-publish.npmrc
+        run: rm -f "$NPM_CONFIG_USERCONFIG"
+
+  release:
+    name: tag-sdk-release
+    needs: publish
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout published source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Create the immutable SDK release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="sdk-v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            test "$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')" = "$GITHUB_SHA"
+          else
+            git tag "$tag" "$GITHUB_SHA"
+            git push origin "$tag"
+          fi
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            release_args=()
+            if [[ "$VERSION" == *-* ]]; then
+              release_args+=(--prerelease)
+            fi
+            gh release create "$tag" \
+              --target "$GITHUB_SHA" \
+              --title "OneWorks Avatar SDK ${VERSION}" \
+              --notes "Publishes @oneworks/avatar, @oneworks/avatar-react, @oneworks/avatar-web, and @oneworks/avatar-vue with npm provenance." \
+              "${release_args[@]}"
+          fi
+          test "$(gh release view "$tag" --json tagName --jq '.tagName')" = "$tag"
+          test "$(gh release view "$tag" --json name --jq '.name')" = "OneWorks Avatar SDK ${VERSION}"
+          expected_prerelease=false
+          if [[ "$VERSION" == *-* ]]; then
+            expected_prerelease=true
+          fi
+          test "$(gh release view "$tag" --json isPrerelease --jq '.isPrerelease')" = "$expected_prerelease"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@ This project is the preview/export surface for the OneWorks avatar visual system
 - `src/App.tsx`: standalone preview/export surface.
 - `src/App.scss`: page layout and interaction styling.
 - `.github/workflows/deploy-avatar.yml`: GitHub Pages deployment owned by the `oneworks-ai/avatar` repository.
+- `.github/workflows/npm-publish.yml`: tokenless npm Trusted Publishing for the four public SDK packages after each npm identity has been bootstrapped once and bound to this workflow; real publishing is restricted to `main`.
+- `scripts/publish-sdk-packages.mjs`: pack, immutable-integrity reconciliation, ordered publish, and npm registry postflight for one shared SDK version.
+
+The npm publisher binding must use repository `oneworks-ai/avatar`, workflow `npm-publish.yml`, environment `npm-publish`, and the `npm publish` allowed action. The protected environment allows only `main`, does not allow administrator bypass, and exposes `NPM_TRUSTED_PUBLISHERS` only after all four bindings have been verified externally and target publishing has no traditional token fallback. Keep validation/packing, OIDC publishing, and GitHub release creation in separate least-privilege jobs.
 - `packages/avatar/`: versioned framework-neutral 3D scene definitions and animation runtime.
 - `packages/react/`: React renderer and the embeddable full editor; it is the single framework adapter allowed to import editor internals.
 - `packages/web/`: Vanilla JS mounts and opt-in custom elements built on the React adapter.

--- a/scripts/publish-sdk-packages.mjs
+++ b/scripts/publish-sdk-packages.mjs
@@ -1,0 +1,236 @@
+import { createHash } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const prepareOnly = process.argv.includes('--prepare-only')
+const publishPrepared = process.argv.includes('--publish-prepared')
+const dryRun = process.argv.includes('--dry-run') || prepareOnly
+const publishTag = process.env.PUBLISH_TAG?.trim() || 'rc'
+const packages = [
+  { directory: 'packages/avatar', name: '@oneworks/avatar' },
+  { directory: 'packages/react', name: '@oneworks/avatar-react' },
+  { directory: 'packages/web', name: '@oneworks/avatar-web' },
+  { directory: 'packages/vue', name: '@oneworks/avatar-vue' }
+]
+
+if (!/^[a-z0-9][a-z0-9._-]*$/u.test(publishTag)) {
+  throw new Error(`Invalid npm publish tag: ${publishTag}`)
+}
+if (prepareOnly && publishPrepared) {
+  throw new Error('--prepare-only and --publish-prepared are mutually exclusive')
+}
+if (publishPrepared && process.env.NPM_PUBLISH_TARBALL_DIRECTORY == null) {
+  throw new Error('--publish-prepared requires NPM_PUBLISH_TARBALL_DIRECTORY')
+}
+
+const run = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? root,
+    encoding: 'utf8',
+    env: { ...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: '0', ...options.env },
+    stdio: options.stdio ?? ['ignore', 'pipe', 'pipe']
+  })
+  if (result.status !== 0 && !options.allowFailure) {
+    process.stderr.write(result.stdout)
+    process.stderr.write(result.stderr)
+    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`)
+  }
+  return result
+}
+
+const readJson = async file => JSON.parse(await readFile(file, 'utf8'))
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))
+const sha512Integrity = bytes => `sha512-${createHash('sha512').update(bytes).digest('base64')}`
+
+const npmView = (selector, field) => {
+  const result = run('npm', ['view', selector, field, '--json'], { allowFailure: true })
+  if (result.status !== 0) return undefined
+  const output = result.stdout.trim()
+  if (output.length === 0) return undefined
+  const value = JSON.parse(output)
+  return typeof value === 'string' ? value : undefined
+}
+
+const verifyRegistryPackage = async ({ integrity, name, version }) => {
+  const selector = `${name}@${version}`
+  for (let attempt = 1; attempt <= 18; attempt += 1) {
+    const registryIntegrity = npmView(selector, 'dist.integrity')
+    const registryTag = npmView(name, `dist-tags.${publishTag}`)
+    const provenancePredicate = npmView(
+      selector,
+      'dist.attestations.provenance.predicateType'
+    )
+    if (
+      registryIntegrity === integrity &&
+      registryTag === version &&
+      provenancePredicate === 'https://slsa.dev/provenance/v1'
+    ) return
+    if (registryIntegrity != null && registryIntegrity !== integrity) {
+      throw new Error(`${selector} exists with a different tarball integrity`)
+    }
+    if (attempt < 18) await sleep(5_000)
+  }
+  throw new Error(`${selector} did not converge in the npm registry with tag ${publishTag}`)
+}
+
+const temporaryRoot = publishPrepared
+  ? undefined
+  : await mkdtemp(path.join(tmpdir(), 'oneworks-avatar-publish-'))
+const tarballDirectory = process.env.NPM_PUBLISH_TARBALL_DIRECTORY == null
+  ? path.join(temporaryRoot, 'tarballs')
+  : path.resolve(process.env.NPM_PUBLISH_TARBALL_DIRECTORY)
+
+try {
+  if (!publishPrepared) await mkdir(tarballDirectory, { recursive: true })
+
+  const manifests = await Promise.all(
+    packages.map(async packageInfo => ({
+      ...packageInfo,
+      manifest: await readJson(path.join(root, packageInfo.directory, 'package.json'))
+    }))
+  )
+  const versions = new Set(manifests.map(item => item.manifest.version))
+  if (versions.size !== 1) throw new Error('All Avatar SDK packages must use one release version')
+  const [version] = versions
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u.test(version)) {
+    throw new Error(`Invalid SDK package version: ${version}`)
+  }
+
+  for (const { directory, manifest, name } of manifests) {
+    if (manifest.name !== name || manifest.private === true) {
+      throw new Error(`Invalid public package identity for ${directory}`)
+    }
+    if (
+      manifest.repository?.url !== 'https://github.com/oneworks-ai/avatar.git' ||
+      manifest.repository?.directory !== directory
+    ) {
+      throw new Error(`Invalid repository metadata for ${name}`)
+    }
+  }
+
+  if (!publishPrepared) {
+    run('pnpm', ['build:sdk'])
+    for (const { name } of packages) {
+      run('pnpm', ['--filter', name, 'pack', '--pack-destination', tarballDirectory])
+    }
+  }
+
+  const tarballNames = await readdir(tarballDirectory)
+  const releasePackages = []
+  for (const { directory, name } of packages) {
+    const tarballName = `${name.slice(1).replace('/', '-')}-${version}.tgz`
+    if (!tarballNames.includes(tarballName)) {
+      throw new Error(`Missing exact packed tarball ${tarballName} for ${name}`)
+    }
+    const tarballPath = path.join(tarballDirectory, tarballName)
+    const packedManifest = JSON.parse(run('tar', ['-xOf', tarballPath, 'package/package.json']).stdout)
+    if (
+      packedManifest.name !== name ||
+      packedManifest.version !== version ||
+      packedManifest.repository?.url !== 'https://github.com/oneworks-ai/avatar.git' ||
+      packedManifest.repository?.directory !== directory
+    ) {
+      throw new Error(`Packed manifest mismatch for ${name}`)
+    }
+    for (const dependency of Object.values(packedManifest.dependencies ?? {})) {
+      if (/^(?:link|workspace):/u.test(String(dependency))) {
+        throw new Error(`Unresolved packed dependency for ${name}: ${dependency}`)
+      }
+    }
+    const integrity = sha512Integrity(await readFile(tarballPath))
+    releasePackages.push({ integrity, name, tarballPath, version })
+  }
+
+  const publicationPlan = []
+  const preflightFailures = []
+  for (const releasePackage of releasePackages) {
+    const selector = `${releasePackage.name}@${version}`
+    const registryIntegrity = npmView(selector, 'dist.integrity')
+    if (registryIntegrity != null) {
+      if (registryIntegrity !== releasePackage.integrity) {
+        throw new Error(`${selector} already exists with a different tarball integrity`)
+      }
+      const registryTag = npmView(releasePackage.name, `dist-tags.${publishTag}`)
+      const provenancePredicate = npmView(
+        selector,
+        'dist.attestations.provenance.predicateType'
+      )
+      let existingValid = true
+      if (registryTag !== version) {
+        preflightFailures.push(`${selector} does not own npm dist-tag ${publishTag}`)
+        existingValid = false
+      }
+      if (provenancePredicate !== 'https://slsa.dev/provenance/v1') {
+        preflightFailures.push(`${selector} has no npm SLSA provenance attestation`)
+        existingValid = false
+      }
+      publicationPlan.push({
+        releasePackage,
+        status: existingValid ? 'existing' : 'invalid-existing'
+      })
+      continue
+    }
+    const identityExists = npmView(releasePackage.name, 'name') === releasePackage.name
+    if (!identityExists) {
+      const message = `${releasePackage.name} must be bootstrapped once and bound to this workflow before tokenless publishing`
+      preflightFailures.push(message)
+    }
+    publicationPlan.push({ releasePackage, status: identityExists ? 'publish' : 'bootstrap' })
+  }
+
+  if (preflightFailures.length > 0 && !dryRun) {
+    throw new Error(`Avatar SDK publish preflight failed before any package was published:\n- ${preflightFailures.join('\n- ')}`)
+  }
+
+  for (const { releasePackage, status } of publicationPlan) {
+    const selector = `${releasePackage.name}@${version}`
+    if (status === 'existing') {
+      process.stdout.write(`Verified existing ${selector}; skipping immutable republish.\n`)
+      continue
+    }
+    if (status === 'invalid-existing') {
+      process.stdout.write(`Dry run: ${selector} failed dist-tag or provenance validation.\n`)
+      continue
+    }
+    if (status === 'bootstrap') {
+      process.stdout.write(`Dry run: ${preflightFailures.find(message => message.startsWith(releasePackage.name))}.\n`)
+      continue
+    }
+    if (dryRun) {
+      process.stdout.write(`Dry run: ${selector} is ready to publish with tag ${publishTag}.\n`)
+      continue
+    }
+    run(
+      'npm',
+      [
+        'publish',
+        releasePackage.tarballPath,
+        '--access',
+        'public',
+        '--tag',
+        publishTag,
+        '--provenance'
+      ],
+      { stdio: 'inherit' }
+    )
+  }
+
+  if (!dryRun) {
+    for (const releasePackage of releasePackages) await verifyRegistryPackage(releasePackage)
+    for (const { name } of releasePackages) {
+      run('npm', ['pack', `${name}@${version}`, '--dry-run', '--json'])
+    }
+    process.stdout.write(`Published and verified OneWorks Avatar SDK ${version}.\n`)
+  }
+
+  if (process.env.GITHUB_OUTPUT != null) {
+    const fs = await import('node:fs/promises')
+    await fs.appendFile(process.env.GITHUB_OUTPUT, `version=${version}\n`)
+  }
+} finally {
+  if (temporaryRoot != null) await rm(temporaryRoot, { force: true, recursive: true })
+}


### PR DESCRIPTION
## Change Brief

- add an Avatar-repository-owned npm Trusted Publishing workflow for the four SDK packages
- fail closed with a complete four-package identity/integrity/provenance preflight before any immutable publish
- split validation/packing, OIDC publishing, and GitHub release creation into separate least-privilege jobs
- publish only prebuilt exact tarballs, reconcile npm dist-tag/integrity/SLSA provenance, and create a prerelease SDK tag

## Validation

- prepared-artifact roundtrip: `--prepare-only` then `--publish-prepared --dry-run`
- real-mode preflight with the current three E404 identities exits before `npm publish`; core rc.6 remains absent
- `node --check scripts/publish-sdk-packages.mjs`
- `git diff --check`

## Bootstrap and trust boundary

`@oneworks/avatar-react`, `@oneworks/avatar-web`, and `@oneworks/avatar-vue` are new npm identities. npm requires each identity to exist before Trusted Publishing can be configured, so they need one controlled pre-target bootstrap. Before the target release, all four publishers must be verified as repository `oneworks-ai/avatar`, workflow `npm-publish.yml`, environment `npm-publish`; only then is the protected environment variable `NPM_TRUSTED_PUBLISHERS` set. The target `1.0.0-rc.6` release remains tokenless OIDC with provenance.

The GitHub `npm-publish` Environment accepts only `main`, disables administrator bypass, and `main` now requires the strict `build-test-pack` status check with force-push/deletion disabled.

## Experience Review

- [x] Reviewed affected developer release workflow
- [x] No end-user UI change
- [x] Release source/provenance now points to the independent Avatar repository
