### PR TITLE
fix: keep camera frame shadows out of exports

### DIFF
--- a/__tests__/avatarCaptureFrame.spec.ts
+++ b/__tests__/avatarCaptureFrame.spec.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { DEFAULT_AVATAR_PIXEL_EFFECT } from '@oneworks/avatar'
+
+vi.mock('../src/avatarPixelation', () => ({
+  renderPixelatedAvatarDataUrl: vi.fn(async () => 'data:image/png;base64,cGl4ZWxz')
+}))
+
+import { renderAvatarSvgSource, serializeAvatarSvg } from '../src/savedAvatarPresets'
+
+const createSourceSvg = () => {
+  const namespace = 'http://www.w3.org/2000/svg'
+  const svg = document.createElementNS(namespace, 'svg')
+  const defs = document.createElementNS(namespace, 'defs')
+  const avatarShadow = document.createElementNS(namespace, 'filter')
+  const body = document.createElementNS(namespace, 'path')
+  svg.setAttribute('viewBox', '0 0 256 256')
+  avatarShadow.setAttribute('id', 'avatar-body-shadow')
+  defs.append(avatarShadow)
+  body.setAttribute('d', 'M 0 0 H 256 V 256 H 0 Z')
+  body.setAttribute('filter', 'url(#avatar-body-shadow)')
+  svg.append(defs, body)
+  return svg
+}
+
+const captureOptions = {
+  background: 'transparent',
+  frameShadow: { color: '#ff0044', direction: 90, distance: 12, opacity: 80, softness: 24 },
+  showFrameShadow: true
+}
+
+const parseCaptureMarkup = (markup: string) => {
+  const container = document.createElement('div')
+  container.innerHTML = markup
+  return container
+}
+
+describe('avatar export camera frame', () => {
+  it.each(['square', 'rounded', 'circle'] as const)(
+    'excludes the preview-only frame shadow from a %s export without shrinking its scene',
+    frame => {
+      const svg = createSourceSvg()
+      const markup = serializeAvatarSvg(svg, 256, { ...captureOptions, frame })
+      const output = parseCaptureMarkup(markup)
+
+      expect(output.querySelector('#oneworks-avatar-export-frame-shadow')).toBeNull()
+      expect(output.querySelector('#oneworks-avatar-export-frame')).not.toBeNull()
+      expect(output.querySelector('#avatar-body-shadow')).not.toBeNull()
+      expect(output.querySelector('[filter="url(#avatar-body-shadow)"]')).not.toBeNull()
+      expect(output.querySelector('[transform*="translate"]')).toBeNull()
+      expect(output.querySelector('[fill="transparent"]')).not.toBeNull()
+      expect(svg.querySelector('#oneworks-avatar-export-frame')).toBeNull()
+
+      const path = output.querySelector('#oneworks-avatar-export-frame path')?.getAttribute('d')
+      if (frame === 'square') expect(path).toBe('M 0 0 H 256 V 256 H 0 Z')
+      if (frame === 'rounded') expect(path).toContain('M 18 0 H 238')
+      if (frame === 'circle') expect(path).toContain('M 128 0 A 128 128')
+    }
+  )
+
+  it('keeps pixelated exports at the full frame size without capturing its preview shadow', async () => {
+    const markup = await renderAvatarSvgSource(createSourceSvg(), 256, {
+      ...captureOptions,
+      frame: 'rounded',
+      pixelEffect: { ...DEFAULT_AVATAR_PIXEL_EFFECT, enabled: true }
+    })
+    const output = parseCaptureMarkup(markup)
+
+    expect(output.querySelector('image')?.getAttribute('href')).toBe('data:image/png;base64,cGl4ZWxz')
+    expect(output.querySelector('image')?.getAttribute('width')).toBe('256')
+    expect(output.querySelector('#oneworks-avatar-export-frame-shadow')).toBeNull()
+    expect(output.querySelector('[transform*="translate"]')).toBeNull()
+  })
+})

--- a/packages/react/__tests__/rendering.spec.tsx
+++ b/packages/react/__tests__/rendering.spec.tsx
@@ -168,10 +168,12 @@ describe('OneWorks Avatar React rendering', () => {
     expect(frame?.style.boxShadow).toBe('none')
   })
 
-  it('captures the definition camera frame shadow in SVG', async () => {
+  it('keeps the camera frame shadow in the preview and out of captured SVG', async () => {
     const definition = createDefaultAvatarDefinition()
     const ref = createRef<AvatarHandle>()
     act(() => root.render(createElement(Avatar, { definition, ref })))
+
+    expect(host.querySelector<HTMLElement>('.oneworks-avatar')?.style.boxShadow).toContain('12.00px')
 
     const blob = await ref.current!.capture({ format: 'svg', size: 256 })
     const source = await new Promise<string>((resolve, reject) => {
@@ -180,10 +182,8 @@ describe('OneWorks Avatar React rendering', () => {
       reader.onload = () => resolve(String(reader.result))
       reader.readAsText(blob)
     })
-    expect(source).toContain('oneworks-avatar-export-frame-shadow')
-    expect(source).toContain('flood-opacity="0.22"')
-    expect(source).toContain('operator="out"')
-    expect(source).toContain('in2="SourceAlpha"')
-    expect(source).toContain('translate(36 36) scale(')
+    expect(source).toContain('oneworks-avatar-export-frame')
+    expect(source).not.toContain('oneworks-avatar-export-frame-shadow')
+    expect(source).not.toContain('translate(36 36) scale(')
   })
 })

--- a/skills/oneworks-avatar/references/editor-workflow.md
+++ b/skills/oneworks-avatar/references/editor-workflow.md
@@ -42,7 +42,7 @@ Use this workflow for creating or refining a OneWorks 3D Avatar through the edit
 
 - Camera mode alone defines export background and crop. The editing surface may show geometry beyond the nominal viewport, so only trust Camera view for edge clearance.
 - Entering Camera mode, changing frame, or opening Animation should not move the character. Treat a shift as a state bug instead of manually repositioning per mode.
-- Choose square, rounded-square, or circle based on the destination. Rounded and circle frames clip camera content at their outer corners regardless of camera background; when frame shadow is enabled, its intentional outside pixels may still reach those corners.
+- Choose square, rounded-square, or circle based on the destination. Rounded and circle frames clip camera content at their outer corners regardless of camera background. Frame shadow remains in the public camera definition and appears in editor/framework on-screen previews, but is never included in exported assets or saved thumbnails.
 - For a transparent asset, select `Transparent` under Style → Camera background and confirm the URL contains `cameraBg=transparent`. The checkerboard is only a UI preview and must not appear in exports.
 
 ## Animation

--- a/skills/oneworks-avatar/references/export-verification.md
+++ b/skills/oneworks-avatar/references/export-verification.md
@@ -13,7 +13,7 @@ Use this reference whenever an Avatar file is requested.
 ## Verify state fidelity
 
 - Compare the export with the reloaded final share URL, not merely the current unpersisted screen.
-- Confirm entity, part materials, rotated depth order, pose, surface face, eye highlights, surface decals, lighting, shadows, outline, background, and frame.
+- Confirm entity, part materials, rotated depth order, pose, surface face, eye highlights, surface decals, lighting, avatar/face shadows, outline, background, and frame. The camera frame shadow is preview-only and must not appear in an export.
 - Confirm highlights remain clipped to their eyes and decals remain clipped to the intended part without filling hollow cavities.
 - For a custom multipart avatar, inspect the target pose and a small yaw/pitch variation before export.
 - Confirm the exported dimensions match the selected size.
@@ -23,7 +23,7 @@ Use this reference whenever an Avatar file is requested.
 - A transparent SVG may omit an opaque camera background or include a frame path with `fill="transparent"`. Reject an opaque camera fill, not the mere existence of a background path.
 - Confirm the checkerboard preview is absent from both SVG and PNG.
 - Confirm a transparent PNG has an alpha channel.
-- For circle and rounded frames, outer corner camera content should be fully transparent. When frame shadow is off, corner pixels should therefore be transparent; when it is on, distinguish intentional semitransparent or dithered shadow pixels from leaked camera content.
+- For circle and rounded frames, outer corner pixels must be fully transparent even when the editor displays a camera frame shadow.
 - For a square frame, inspect an exposed background region or the alpha histogram when transparent background is visible. Do not require a transparent corner if the avatar deliberately fills that corner.
 - Reopen the file independently; a successful browser download event alone is insufficient.
 
@@ -33,7 +33,7 @@ Use this reference whenever an Avatar file is requested.
 - Confirm the beginning matches the selected first-frame behavior.
 - Confirm the ending and loop metadata match Once or Loop.
 - Check that the entity, camera crop, background transparency, and composition remain stable while intended pose/face/color changes animate.
-- Check frame shadow consistently across SVG, PNG, and GIF. A transparent square export must keep its center clear while preserving the intended outside shadow inside the capture inset.
-- Treat GIF transparency as a constrained indexed format; semitransparent shadows use alpha dithering, so inspect edges against the intended destination background when visual quality matters.
+- Check that camera frame shadow is absent across SVG, PNG, and GIF and that the frame fills the export without an artificial shadow inset.
+- Treat GIF transparency as a constrained indexed format; inspect antialiased avatar edges against the intended destination background when visual quality matters.
 
 If any check fails, correct the editor state and export again. Do not post-process a mismatched file into apparent compliance.

--- a/src/savedAvatarPresets.ts
+++ b/src/savedAvatarPresets.ts
@@ -60,26 +60,22 @@ export const prependSavedAvatarPreset = (
   preset: SavedAvatarPreset
 ) => [preset, ...presets].slice(0, MAX_SAVED_PRESETS)
 
-const getAvatarFramePath = (width: number, height: number, frame: AvatarCameraFrame, inset = 0) => {
-  const innerWidth = Math.max(width - inset * 2, 1)
-  const innerHeight = Math.max(height - inset * 2, 1)
+const getAvatarFramePath = (width: number, height: number, frame: AvatarCameraFrame) => {
   if (frame === 'circle') {
-    const radius = Math.min(innerWidth, innerHeight) / 2
+    const radius = Math.min(width, height) / 2
     return `M ${width / 2} ${height / 2 - radius} A ${radius} ${radius} 0 1 1 ${width / 2} ${
       height / 2 + radius
     } A ${radius} ${radius} 0 1 1 ${width / 2} ${height / 2 - radius} Z`
   }
   if (frame === 'rounded') {
-    const right = width - inset
-    const bottom = height - inset
-    const radius = Math.min(innerWidth, innerHeight) * 18 / SCREENSHOT_SIZE
-    return `M ${inset + radius} ${inset} H ${right - radius} Q ${right} ${inset} ${right} ${inset + radius} V ${
-      bottom - radius
-    } Q ${right} ${bottom} ${right - radius} ${bottom} H ${inset + radius} Q ${inset} ${bottom} ${inset} ${
-      bottom - radius
-    } V ${inset + radius} Q ${inset} ${inset} ${inset + radius} ${inset} Z`
+    const radius = Math.min(width, height) * 18 / SCREENSHOT_SIZE
+    return `M ${radius} 0 H ${width - radius} Q ${width} 0 ${width} ${radius} V ${
+      height - radius
+    } Q ${width} ${height} ${width - radius} ${height} H ${radius} Q 0 ${height} 0 ${
+      height - radius
+    } V ${radius} Q 0 0 ${radius} 0 Z`
   }
-  return `M ${inset} ${inset} H ${width - inset} V ${height - inset} H ${inset} Z`
+  return `M 0 0 H ${width} V ${height} H 0 Z`
 }
 
 const applyAvatarCaptureFrame = (svg: SVGSVGElement, options: AvatarCaptureOptions) => {
@@ -92,83 +88,27 @@ const applyAvatarCaptureFrame = (svg: SVGSVGElement, options: AvatarCaptureOptio
   const document = svg.ownerDocument
   const namespace = 'http://www.w3.org/2000/svg'
   const clipId = 'oneworks-avatar-export-frame'
-  const shadowFilterId = 'oneworks-avatar-export-frame-shadow'
   const defs = document.createElementNS(namespace, 'defs')
   const clipPath = document.createElementNS(namespace, 'clipPath')
   const framePath = document.createElementNS(namespace, 'path')
   const content = document.createElementNS(namespace, 'g')
   const scene = document.createElementNS(namespace, 'g')
-  const shadowInset = options.showFrameShadow && options.frameShadow != null && options.frameShadow.opacity > 0
-    ? Math.min(
-      Math.max(options.frameShadow.distance + options.frameShadow.softness, 1),
-      Math.min(width, height) / 4
-    )
-    : 0
 
   clipPath.setAttribute('id', clipId)
-  framePath.setAttribute('d', getAvatarFramePath(width, height, frame, shadowInset))
+  framePath.setAttribute('d', getAvatarFramePath(width, height, frame))
   clipPath.append(framePath)
   defs.append(clipPath)
-
-  let shadowPath: SVGPathElement | null = null
-  if (options.showFrameShadow && options.frameShadow != null) {
-    const direction = options.frameShadow.direction * Math.PI / 180
-    const filter = document.createElementNS(namespace, 'filter')
-    const blur = document.createElementNS(namespace, 'feGaussianBlur')
-    const offset = document.createElementNS(namespace, 'feOffset')
-    const flood = document.createElementNS(namespace, 'feFlood')
-    const outside = document.createElementNS(namespace, 'feComposite')
-    const colorize = document.createElementNS(namespace, 'feComposite')
-    filter.setAttribute('id', shadowFilterId)
-    filter.setAttribute('x', '-50%')
-    filter.setAttribute('y', '-50%')
-    filter.setAttribute('width', '200%')
-    filter.setAttribute('height', '200%')
-    blur.setAttribute('in', 'SourceAlpha')
-    blur.setAttribute('stdDeviation', String(options.frameShadow.softness / 2))
-    blur.setAttribute('result', 'blur')
-    offset.setAttribute('in', 'blur')
-    offset.setAttribute('dx', String(Math.cos(direction) * options.frameShadow.distance))
-    offset.setAttribute('dy', String(Math.sin(direction) * options.frameShadow.distance))
-    offset.setAttribute('result', 'offset')
-    flood.setAttribute('flood-color', options.frameShadow.color ?? '#000000')
-    flood.setAttribute('flood-opacity', String(options.frameShadow.opacity / 100))
-    flood.setAttribute('result', 'color')
-    outside.setAttribute('in', 'offset')
-    outside.setAttribute('in2', 'SourceAlpha')
-    outside.setAttribute('operator', 'out')
-    outside.setAttribute('result', 'outside')
-    colorize.setAttribute('in', 'color')
-    colorize.setAttribute('in2', 'outside')
-    colorize.setAttribute('operator', 'in')
-    filter.append(blur, offset, outside, flood, colorize)
-    defs.append(filter)
-
-    shadowPath = document.createElementNS(namespace, 'path')
-    shadowPath.setAttribute('d', getAvatarFramePath(width, height, frame, shadowInset))
-    shadowPath.setAttribute('fill', '#000000')
-    shadowPath.setAttribute('filter', `url(#${shadowFilterId})`)
-  }
 
   content.setAttribute('clip-path', `url(#${clipId})`)
   if (options.background != null) {
     const background = document.createElementNS(namespace, 'path')
-    background.setAttribute('d', getAvatarFramePath(width, height, frame, shadowInset))
+    background.setAttribute('d', getAvatarFramePath(width, height, frame))
     background.setAttribute('fill', options.background)
     content.append(background)
-  }
-  if (shadowInset > 0) {
-    scene.setAttribute(
-      'transform',
-      `translate(${shadowInset} ${shadowInset}) scale(${(width - shadowInset * 2) / width} ${
-        (height - shadowInset * 2) / height
-      })`
-    )
   }
   while (svg.firstChild != null) scene.append(svg.firstChild)
   content.append(scene)
   svg.append(defs)
-  if (shadowPath != null) svg.append(shadowPath)
   svg.append(content)
 }
 


### PR DESCRIPTION
## Summary

- Keep the camera frame shadow in the public camera definition and editor/framework previews.
- Remove only the export frame-shadow filter and inset so SVG, PNG, and GIF captures use the full selected frame.
- Preserve avatar body shadow, face shadow, background/transparency, clipping, and pixel-export behavior.

## Preview/export boundary

The camera frame shadow remains available to on-screen previews and remains part of the public definition for compatibility. It is intentionally absent from exported SVG, PNG, GIF, and saved thumbnails. Rounded and circle exports retain full-frame clipping without an artificial shadow inset.

## Tests and validation

- `pnpm vitest run __tests__/avatarCaptureFrame.spec.ts packages/react/__tests__/rendering.spec.tsx __tests__/avatarAnimations.spec.ts __tests__/InteractiveAvatarPixel.spec.ts __tests__/AppPixelEffect.spec.ts` — 30 tests passed.
- `pnpm vitest run __tests__/avatarGifExport.spec.ts __tests__/avatarPixelation.spec.ts` — 11 tests passed.
- `pnpm typecheck` — passed.
- `git diff --cached --check` — passed before commit.
- `__tests__/avatarCaptureFrame.spec.ts` matches the reviewed source hash `177257d8e6907778344339e9720704e450863a4628e2040050c88da190eaffb3`.

The workspace SDK build generated the avatar package successfully; the aggregate React SDK build remains blocked by the existing missing `app-source/packages/route-layout/src/design-tokens.css` generated path in this isolated checkout.

## Independent review evidence

- Independent code review: PASS (main task evidence).
- Independent visual review: PASS (main task evidence).

## Experience Review

- [x] I reviewed the user-facing experience for this change.
- [x] I verified that the change preserves the intended preview behavior.
- [x] I verified that the change preserves export behavior and compatibility boundaries.

## Scope

This PR contains only the focused camera-frame export boundary change and its regression/documentation coverage. It does not include concurrent Cat, coat, Seed, or other avatar edits.
