### PR TITLE
chore(ci): add lightweight Avatar documentation validation

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -2,19 +2,6 @@ name: Avatar SDK CI
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/sdk-ci.yml
-      - .github/workflows/npm-publish.yml
-      - AGENTS.md
-      - package.json
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
-      - packages/**
-      - scripts/**
-      - src/**
-      - tsconfig*.json
-      - vite.config.ts
-      - vitest.config.ts
   push:
     branches: [main]
   workflow_dispatch:
@@ -34,8 +21,269 @@ jobs:
     steps:
       - name: Checkout Avatar repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify validation scope
+        id: scope
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          scope=full
+          if [[ "$EVENT_NAME" != workflow_dispatch ]] &&
+             [[ "$BASE_SHA" =~ ^[[:xdigit:]]{40}$ ]] &&
+             [[ "$HEAD_SHA" =~ ^[[:xdigit:]]{40}$ ]] &&
+             git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null &&
+             git cat-file -e "$HEAD_SHA^{commit}" 2>/dev/null; then
+            mapfile -d '' -t changes < <(git diff --name-status --no-renames -z "$BASE_SHA" "$HEAD_SHA")
+            if (( ${#changes[@]} > 0 && ${#changes[@]} % 2 == 0 )); then
+              scope=documentation
+              documentation_pattern='^(README(\.[[:alnum:]_-]+)?\.md|AGENTS\.md|packages/[[:alnum:]_.-]+/(README(\.[[:alnum:]_-]+)?|AGENTS)\.md|\.github/assets/[[:alnum:]_.-]+\.(png|jpe?g|gif|webp)|docs(/[[:alnum:]_.-]+)+\.(md|png|jpe?g|gif|webp|svg)|skills/[a-z0-9]+(-[a-z0-9]+)*/(SKILL\.md|references/[[:alnum:]_.-]+\.md|agents/openai\.yaml))$'
+
+              for (( index = 0; index < ${#changes[@]}; index += 2 )); do
+                change_status=${changes[index]}
+                changed_path=${changes[index + 1]}
+
+                if [[ ! "$change_status" =~ ^[AM]$ ]] ||
+                   [[ ! "$changed_path" =~ $documentation_pattern ]]; then
+                  scope=full
+                  break
+                fi
+
+                head_entry=$(git ls-tree "$HEAD_SHA" -- "$changed_path")
+                if [[ ! "$head_entry" =~ ^100644[[:space:]]blob[[:space:]][[:xdigit:]]{40}[[:space:]] ]]; then
+                  scope=full
+                  break
+                fi
+
+                if [[ "$change_status" == M ]]; then
+                  base_entry=$(git ls-tree "$BASE_SHA" -- "$changed_path")
+                  if [[ ! "$base_entry" =~ ^100644[[:space:]]blob[[:space:]][[:xdigit:]]{40}[[:space:]] ]]; then
+                    scope=full
+                    break
+                  fi
+                fi
+              done
+            fi
+          fi
+
+          printf 'scope=%s\nbase=%s\nhead=%s\n' "$scope" "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          printf 'Validation scope: %s\n' "$scope"
+
+      - name: Validate documentation and skill metadata
+        if: steps.scope.outputs.scope == 'documentation'
+        shell: bash
+        env:
+          BASE_SHA: ${{ steps.scope.outputs.base }}
+          HEAD_SHA: ${{ steps.scope.outputs.head }}
+        run: |
+          set -euo pipefail
+          git diff --check "$BASE_SHA" "$HEAD_SHA"
+
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+          import subprocess
+          import xml.etree.ElementTree
+
+          root = pathlib.Path.cwd().resolve()
+          changed = subprocess.check_output(
+              [
+                  "git", "diff", "--name-only", "--no-renames", "-z",
+                  os.environ["BASE_SHA"], os.environ["HEAD_SHA"],
+              ]
+          ).decode().rstrip("\0").split("\0")
+          skill_roots = {
+              root / pathlib.Path(path).parts[0] / pathlib.Path(path).parts[1]
+              for path in changed
+              if pathlib.Path(path).parts[0] == "skills"
+          }
+          markdown_files = {root / path for path in changed if path.endswith(".md")}
+          media_files = {
+              root / path
+              for path in changed
+              if pathlib.Path(path).suffix.lower() in {".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"}
+          }
+
+          ruby_yaml_parser = r"""
+          require "json"
+          require "yaml"
+
+          source = STDIN.read
+          filename = ENV.fetch("YAML_SOURCE")
+          documents = Psych.parse_stream(source, filename: filename)
+          raise "Expected exactly one YAML document" unless documents.children.length == 1
+
+          validate = lambda do |node|
+            if node.is_a?(Psych::Nodes::Mapping)
+              keys = {}
+              node.children.each_slice(2) do |key, value|
+                raise "YAML mapping keys must be scalar values" unless key.is_a?(Psych::Nodes::Scalar)
+                raise "Duplicate YAML key: #{key.value}" if keys.key?(key.value)
+                keys[key.value] = true
+                validate.call(value)
+              end
+            else
+              Array(node.children).each { |child| validate.call(child) } if node.respond_to?(:children)
+            end
+          end
+          documents.children.each { |document| validate.call(document.root) }
+
+          value = YAML.safe_load(source, permitted_classes: [], permitted_symbols: [], aliases: false)
+          raise "Expected a YAML mapping" unless value.is_a?(Hash)
+          STDOUT.write(JSON.generate(value))
+          """
+
+          def load_yaml(source, path):
+              result = subprocess.run(
+                  ["ruby", "-r", "yaml", "-r", "json", "-e", ruby_yaml_parser],
+                  input=source,
+                  text=True,
+                  capture_output=True,
+                  env={**os.environ, "YAML_SOURCE": str(path.relative_to(root))},
+              )
+              if result.returncode:
+                  raise SystemExit(f"Invalid YAML in {path.relative_to(root)}: {result.stderr.strip()}")
+              return json.loads(result.stdout)
+
+          for media_file in sorted(media_files):
+              if media_file.is_symlink() or not media_file.is_file():
+                  raise SystemExit(f"Documentation media must be a regular file: {media_file.relative_to(root)}")
+
+              data = media_file.read_bytes()
+              if not data or len(data) > 10 * 1024 * 1024:
+                  raise SystemExit(f"Invalid documentation media size: {media_file.relative_to(root)}")
+
+              suffix = media_file.suffix.lower()
+              signatures = {
+                  ".gif": data.startswith((b"GIF87a", b"GIF89a")) and data.endswith(b";"),
+                  ".jpeg": data.startswith(b"\xff\xd8\xff") and data.endswith(b"\xff\xd9"),
+                  ".jpg": data.startswith(b"\xff\xd8\xff") and data.endswith(b"\xff\xd9"),
+                  ".png": data.startswith(b"\x89PNG\r\n\x1a\n"),
+                  ".webp": data.startswith(b"RIFF") and data[8:12] == b"WEBP",
+              }
+              if suffix != ".svg":
+                  if not signatures.get(suffix, False):
+                      raise SystemExit(f"Invalid documentation image: {media_file.relative_to(root)}")
+                  continue
+
+              source = data.decode("utf-8")
+              if re.search(r"<!\s*(?:DOCTYPE|ENTITY)\b|<\?\s*xml-stylesheet\b", source, re.I):
+                  raise SystemExit(f"Unsafe SVG declaration: {media_file.relative_to(root)}")
+              try:
+                  svg = xml.etree.ElementTree.fromstring(source)
+              except xml.etree.ElementTree.ParseError as error:
+                  raise SystemExit(f"Invalid SVG document {media_file.relative_to(root)}: {error}") from error
+              if svg.tag not in {"svg", "{http://www.w3.org/2000/svg}svg"}:
+                  raise SystemExit(f"Invalid SVG root: {media_file.relative_to(root)}")
+              for element in svg.iter():
+                  tag = element.tag.rsplit("}", 1)[-1].lower()
+                  if tag in {"script", "foreignobject", "iframe", "object", "embed", "style"}:
+                      raise SystemExit(f"Active SVG element is not allowed: {media_file.relative_to(root)}")
+                  for attribute, value in element.attrib.items():
+                      attribute = attribute.rsplit("}", 1)[-1].lower()
+                      if attribute.startswith("on") or re.search(
+                          r"(?:javascript\s*:|data\s*:|https?\s*:|//|@import)", value, re.I
+                      ):
+                          raise SystemExit(f"Unsafe SVG attribute is not allowed: {media_file.relative_to(root)}")
+                      if attribute in {"href", "src"} and re.fullmatch(r"#[A-Za-z_][A-Za-z0-9_.:-]*", value) is None:
+                          raise SystemExit(f"External SVG resource is not allowed: {media_file.relative_to(root)}")
+                      for reference in re.findall(r"url\s*\(([^)]*)\)", value, re.I):
+                          if re.fullmatch(r"\s*#[A-Za-z_][A-Za-z0-9_.:-]*\s*", reference) is None:
+                              raise SystemExit(f"External SVG reference is not allowed: {media_file.relative_to(root)}")
+
+          for skill_root in sorted(skill_roots):
+              skill_file = skill_root / "SKILL.md"
+              if skill_file.is_symlink() or not skill_file.is_file():
+                  raise SystemExit(f"Missing regular skill file: {skill_file.relative_to(root)}")
+              content = skill_file.read_text(encoding="utf-8")
+              frontmatter = re.match(r"\A---\r?\n(.*?)\r?\n---(?:\r?\n|\Z)", content, re.S)
+              if frontmatter is None:
+                  raise SystemExit(f"Missing valid YAML frontmatter: {skill_file.relative_to(root)}")
+
+              skill_metadata = load_yaml(frontmatter.group(1), skill_file)
+              name = skill_metadata.get("name")
+              description = skill_metadata.get("description")
+              if not isinstance(name, str) or name != skill_root.name or len(name) > 64:
+                  raise SystemExit(f"Invalid skill name: {skill_file.relative_to(root)}")
+              if not isinstance(description, str) or not description.strip() or len(description) > 1024:
+                  raise SystemExit(f"Invalid skill description: {skill_file.relative_to(root)}")
+
+              metadata_file = skill_root / "agents" / "openai.yaml"
+              if metadata_file.exists():
+                  if metadata_file.is_symlink() or not metadata_file.is_file():
+                      raise SystemExit(f"Skill metadata must be a regular file: {metadata_file.relative_to(root)}")
+                  metadata = load_yaml(metadata_file.read_text(encoding="utf-8"), metadata_file)
+                  interface = metadata.get("interface")
+                  if not isinstance(interface, dict):
+                      raise SystemExit(f"Invalid skill interface: {metadata_file.relative_to(root)}")
+                  short_description = interface.get("short_description")
+                  default_prompt = interface.get("default_prompt")
+                  if not isinstance(short_description, str) or not 25 <= len(short_description) <= 64:
+                      raise SystemExit(f"Invalid skill short description: {metadata_file.relative_to(root)}")
+                  if not isinstance(default_prompt, str) or f"${name}" not in default_prompt:
+                      raise SystemExit(f"Invalid skill default prompt: {metadata_file.relative_to(root)}")
+
+              markdown_files.update(skill_root.rglob("*.md"))
+
+          for markdown_file in sorted(markdown_files):
+              if markdown_file.is_symlink() or not markdown_file.is_file():
+                  raise SystemExit(f"Documentation must be a regular file: {markdown_file.relative_to(root)}")
+
+              markdown = markdown_file.read_text(encoding="utf-8")
+              if not markdown.strip():
+                  raise SystemExit(f"Documentation must not be empty: {markdown_file.relative_to(root)}")
+
+              skill_root = next((path for path in skill_roots if markdown_file.is_relative_to(path)), None)
+              boundary = skill_root if skill_root is not None else root
+              targets = re.findall(r"\[[^\]]*\]\(([^\s)]+)(?:\s+[^)]*)?\)", markdown)
+              targets.extend(re.findall(r"\b(?:href|src)\s*=\s*[\"']([^\"']+)[\"']", markdown, re.I))
+              for source_set in re.findall(r"\bsrcset\s*=\s*[\"']([^\"']+)[\"']", markdown, re.I):
+                  targets.extend(candidate.strip().split()[0] for candidate in source_set.split(",") if candidate.strip())
+              for target in targets:
+                  if target.startswith("#"):
+                      continue
+                  if re.match(r"^(?:https?|mailto|tel):", target, re.I):
+                      continue
+                  if target.startswith("/") or re.match(r"^[a-z][a-z0-9+.-]*:", target, re.I):
+                      raise SystemExit(f"Non-portable documentation link in {markdown_file.relative_to(root)}: {target}")
+
+                  local_target = markdown_file.parent / target.split("#", 1)[0].split("?", 1)[0]
+                  target_path = local_target.resolve()
+                  if not target_path.is_relative_to(boundary) or not target_path.is_file():
+                      raise SystemExit(f"Invalid documentation link in {markdown_file.relative_to(root)}: {target}")
+                  for ancestor in (local_target, *local_target.parents):
+                      if ancestor == boundary:
+                          break
+                      if ancestor.is_symlink():
+                          raise SystemExit(f"Symbolic-link documentation target in {markdown_file.relative_to(root)}: {target}")
+
+          added = subprocess.check_output(
+              ["git", "diff", "--unified=0", os.environ["BASE_SHA"], os.environ["HEAD_SHA"], "--", *changed]
+          ).decode().splitlines()
+          private_pattern = re.compile(
+              r"(?:\b(?:gho|ghp|ghu|ghs|ghr)_[A-Za-z0-9]{20,}|\bgithub_pat_\w{20,}|"
+              r"\bsk-[\w-]{20,}|\bAKIA[0-9A-Z]{16}\b|BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY|"
+              r"/(?:Users|home)/(?!<(?:user|username)>/|\{(?:user|username)\}/|"
+              r"\$(?:USER(?:NAME)?|\{USER(?:NAME)?\})/|USER(?:NAME)?/)[^/\s`]+/|"
+              r"\.codex/worktrees/[0-9a-f-]{4,}/|\.oo/worktrees/sessions/[\w-]{4,}/)", re.I
+          )
+          for line in added:
+              if line.startswith("+") and not line.startswith("+++") and private_pattern.search(line):
+                  raise SystemExit("Added documentation contains a secret or private local path")
+
+          print(f"Validated {len(changed)} documentation file(s) across {len(skill_roots)} skill(s).")
+          PY
 
       - name: Checkout shared OneWorks sources
+        if: steps.scope.outputs.scope != 'documentation'
         uses: actions/checkout@v4
         with:
           repository: oneworks-ai/app
@@ -43,33 +291,42 @@ jobs:
           submodules: false
 
       - name: Setup pnpm
+        if: steps.scope.outputs.scope != 'documentation'
         uses: pnpm/action-setup@v4
         with:
           version: 11.7.0
 
       - name: Setup Node.js
+        if: steps.scope.outputs.scope != 'documentation'
         uses: actions/setup-node@v4
         with:
           node-version-file: app-source/.node-version
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
+        if: steps.scope.outputs.scope != 'documentation'
         run: pnpm install --frozen-lockfile
 
       - name: Test editor and runtime contracts
+        if: steps.scope.outputs.scope != 'documentation'
         run: pnpm test
 
       - name: Typecheck app source
+        if: steps.scope.outputs.scope != 'documentation'
         run: pnpm typecheck
 
       - name: Build and typecheck SDK packages
+        if: steps.scope.outputs.scope != 'documentation'
         run: pnpm typecheck:sdk
 
       - name: Build app source
+        if: steps.scope.outputs.scope != 'documentation'
         run: pnpm build:app-source
 
       - name: Test packed packages in a clean consumer
+        if: steps.scope.outputs.scope != 'documentation'
         run: pnpm smoke:sdk
 
       - name: Audit production dependencies
+        if: steps.scope.outputs.scope != 'documentation'
         run: pnpm audit --prod --audit-level high

--- a/skills/oneworks-avatar/SKILL.md
+++ b/skills/oneworks-avatar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oneworks-avatar
-description: Create, refine, debug, export, and integrate editable OneWorks 3D geometric avatars. Use for avatars, mascots, bot or agent portraits, multipart 3D characters, OneWorks Avatar share URLs, transparent SVG or PNG, animated GIF, developer handoff, React or JavaScript integration, embed questions, @oneworks/avatar integration, or investigation of pose, projection, depth, camera, export, and animation issues. Do not use for photorealistic portraits or arbitrary raster illustration.
+description: Create, refine, debug, export, and integrate editable OneWorks 3D geometric avatars. Use for avatars, mascots, bot or agent portraits, multipart 3D characters, cat breeds, character presets, expressive eyes, coat patterns, controlled Seed variation, avatar composition, OneWorks Avatar share URLs, transparent SVG or PNG, animated GIF, developer handoff, React or JavaScript integration, embed questions, @oneworks/avatar integration, or investigation of pose, projection, depth, camera, export, and animation issues. Do not use for photorealistic portraits or arbitrary raster illustration.
 ---
 
 # OneWorks Avatar
@@ -18,6 +18,8 @@ Work with the official OneWorks 3D geometric avatar system. Treat the editor URL
 
 - Think in three spaces: part-local geometry, whole-entity 3D pose, and 2D camera composition. Fix a problem in the space where it originates.
 - Keep the same scene state across editor preview, share URL, saved preset, animation, SVG, PNG, and GIF. A result that looks similar but comes from a different state is not equivalent.
+- Separate the entity type, an optional constrained character profile, and saved complete looks. Profiles express which identity features stay fixed and which values may vary; the resolved concrete scene remains the rendering source of truth.
+- Treat Seed as deterministic, field-specific authoring. Preserve the character's species, natural palette, camera frame, and manually fixed choices unless a supported applicable field explicitly follows Seed.
 - Preserve true local X/Y/Z transforms, entity yaw/pitch/roll, projection, rotated-depth ordering, surface-projected face geometry, camera crop, lighting, and effects.
 - Use the real editor and export pipeline. Do not rebuild the avatar from DOM fragments, rendered SVG paths, URL tuple internals, or a prompt-generated image.
 - Treat a complete editor-generated URL as an opaque editable source. Do not promote its private query parameters to a public API or hand-author serialized `entityParts` or `animationData`.
@@ -25,7 +27,7 @@ Work with the official OneWorks 3D geometric avatar system. Treat the editor URL
 
 ## Universal workflow
 
-1. Parse the request for subject, personality, palette, 3D shape language, target pose, expression, background, frame, motion, integration target, formats, and sizes.
+1. Parse the request for subject, personality, palette, 3D shape language, target pose, expression, background, frame, motion, identity features that must remain fixed, allowed variation, integration target, formats, and sizes.
 2. If the user supplies a OneWorks Avatar URL, open and reload it before editing. Preserve every unspecified choice.
 3. Inspect concise product context when it materially helps. Ask one compact round of questions only when a missing choice would change the result; otherwise choose sensible defaults and proceed.
 4. Determine the available browser path before promising operated or exported output. Prefer an already-running local editor when the user is reviewing it; otherwise use `https://oneworks.cloud/avatar/`. If no interactive browser is available, explain the limitation instead of fabricating results.

--- a/skills/oneworks-avatar/agents/openai.yaml
+++ b/skills/oneworks-avatar/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "OneWorks Avatar"
-  short_description: "Create, debug, export, and integrate 3D avatars"
-  default_prompt: "Use $oneworks-avatar to create or integrate an editable 3D avatar for my product."
+  short_description: "Create expressive 3D avatars and character presets"
+  default_prompt: "Use $oneworks-avatar to create, refine, or integrate an expressive editable 3D avatar with stable identity and controlled variation."
 
 policy:
   allow_implicit_invocation: true

--- a/skills/oneworks-avatar/references/3d-debugging.md
+++ b/skills/oneworks-avatar/references/3d-debugging.md
@@ -27,6 +27,7 @@ Do not repair a lower-layer defect in a later layer. Examples: do not move an ea
 
 - Rotate a custom multipart entity slightly on both yaw and pitch. Near-side attachments must remain in front and far-side parts must pass behind coherently.
 - Confirm the face follows the same 3D pose as the primary body and disappears naturally behind tangent/back-facing regions.
+- Move procedural markings or decals near a silhouette edge, then vary yaw and pitch. Clip `front`, `left`, `right`, and `back` surface geometry at the visible hemisphere so no isolated fragment floats away; keep `side: "face"` patches on the same face-plane projection as the facial features.
 - Confirm multipart pieces intended to fuse remain solid; inappropriate overlap subtraction often presents as hollow rings.
 - Push a highlight toward the eye edge and a decal toward the target-part edge, then rotate slightly. Neither may escape its projected clip, and a decal must not cover a hollow cavity.
 - Enter and leave Camera and Animation without accepting geometry shifts.
@@ -34,6 +35,16 @@ Do not repair a lower-layer defect in a later layer. Examples: do not move an ea
 - Reload transparent and colored camera URLs and confirm the selected background mode survives.
 - For an animation, compare the chosen first frame, stage anchor, Once/Loop behavior, and GIF beginning/end.
 - If both live preview and GIF jump at the first frame, inspect selected start frame, playback re-anchor, and first-frame timing. If preview is correct and only GIF jumps, inspect the first generated sample and offscreen render state in `avatarGifExport.tsx`.
+
+## Preserve the full authoring chain
+
+- For an optional face dimension, update public ranges and strict validation, editor defaults, URL parsing/serialization, definition conversion, actual projected eye geometry, animation-patch validation/interpolation, face-transition dependencies, and all framework renderers. Old definitions without the field must stay valid and must not trigger spurious changes.
+- Replace a selected face preset as a complete style rather than merging it over the previous one. Verify old optional left/right eye widths and heights disappear from concrete state and the share URL.
+- Keep Cat-profile fixed values, allowed Seed fields, candidate palettes, per-field domains, real scene preview, URL restoration, and public definition aligned. A profile may narrow a public numeric range but must never generate values outside it.
+- Exclude the camera frame from active Seed application and legacy Seed-field parsing while preserving its compatibility field-path identifier, manual control, concrete URL state, public definitions, and exports.
+- For seeded view motion, persist the final view once, interpolate only transient rendering state, continue rapid rerolls from the currently visible state, cancel stale frames on direct manipulation or playback, and honor `prefers-reduced-motion`.
+- Translate every newly exposed preset name, tooltip, and accessible label. Overflowing preset catalogs need an accessible entry to the complete list; dark-avatar preview backgrounds must never mutate real camera state.
+- Keep procedural coat rendering in the shared public resolver. Preserve independently authored decals and materialize generated markings only through the explicit conversion action.
 
 ## Source map
 
@@ -43,11 +54,17 @@ When working in the `oneworks-ai/avatar` repository, start with the nearest rele
 - `src/InteractiveAvatar.tsx`: assembled rendering, materials, projection, highlight/decal clips, occlusion, and depth ordering.
 - `src/avatarSurfaceDecals.ts`: decal schema, URL normalization, target-part semantics, and defaults.
 - `src/avatarEntityPresets.ts`: built-in multipart geometry, materials, scene defaults, and serialization defaults.
+- `src/avatarBreedTemplates.ts`: Cat-profile identity constraints, natural palette domains, permitted Seed variation, and preview-only backgrounds.
+- `src/avatarFacePresets.ts`: authored rounded-eye expressions and complete face-style replacement defaults.
+- `src/avatarSeed.ts`: supported Seed fields, deterministic candidate/range selection, legacy-field filtering, and constrained domains.
+- `src/AvatarControls.tsx`: actual rendered preset previews, profile selection, Seed-follow toggles, and face/coat controls.
+- `src/avatarDefinition.ts`: conversion between the public definition, concrete editor state, and complete share URL.
 - `src/AvatarOrientationControl.tsx`: yaw, pitch, and shared roll controls.
 - `src/App.tsx`: URL state, scene composition, preset restore, camera/export routing, and animation coordination.
 - `src/savedAvatarPresets.ts`: SVG serialization, camera background/frame application, and PNG capture.
 - `src/avatarGifExport.tsx`: animation resolution, sampling, offscreen rendering, transparency, and GIF encoding.
 - `packages/avatar/src/index.ts`: public definition schema, shared range constants, strict parsing, animation application, and runtime resolution.
+- `packages/avatar/src/catalog.ts`: entity-wide palette materials and optional part-specific/coat color descriptors.
 - `src/avatarAnimations.ts`: presets, keyframes, timing, easing, start frame, Once/Loop, and persistence.
 
 ## Verification

--- a/skills/oneworks-avatar/references/editor-workflow.md
+++ b/skills/oneworks-avatar/references/editor-workflow.md
@@ -5,8 +5,22 @@ Use this workflow for creating or refining a OneWorks 3D Avatar through the edit
 ## Establish the scene
 
 1. Decide the requested output before fine-tuning: static or animated, opaque or transparent, square/rounded/circle frame, and `128`, `256`, or `512` pixels. Default to `256` only when the user has no size preference.
-2. Choose an entity before detailed edits. Built-in cloud, sun, cat, dog, bear, and rabbit presets restore authored geometry, face, material, camera, pose, outline, and shadow, so selecting one late may replace existing work.
+2. Choose an entity before detailed edits. Built-in cloud, sun, cat, dog, bear, rabbit, and bun presets restore authored geometry, face, material, camera, pose, outline, and shadow, so selecting one late may replace existing work.
 3. Use a custom body or multipart entity when the silhouette needs independent depths, rotations, tapered forms, hollows, or attachments. Available primitives include sphere, ellipse, square, rounded square, capsule, teardrop, diamond, rounded trapezoid, cone, frustum, and half-cone.
+
+## Character identity and Cat profiles
+
+- Keep **Avatar type**, optional **Cat type**, and **Saved looks** separate. The avatar type selects actual multipart geometry; a Cat type constrains identity and Seed variation; a saved look restores a complete concrete scene.
+- Render avatar-type and Cat-type cards from their actual resolved geometry, materials, and procedural coat. Use consistent thumbnail sizing and translated accessible names rather than hand-drawn substitutes or visible duplicate labels.
+- Selecting an already-active Cat type removes its profile constraint without discarding the current appearance. Preserve the Cat head size; derive ear changes from canonical Cat parts so repeated edits do not compound.
+- Author the existing Cat profiles by their recognizable fixed identity and only vary their declared fields:
+  - **Siamese:** cream head, chocolate ears, horizontally centered dark elliptical muzzle at a fixed vertical offset, and no stripes; vary muzzle length and width while keeping its position and palette fixed.
+  - **British Shorthair:** warm golden-brown and beige materials, shorter ears, broad face mask, and restrained classic markings; vary marking density and mask size.
+  - **Russian Blue:** coherent blue-gray materials with no procedural markings; vary ear width and height.
+  - **Orange Tabby:** warm orange materials, paired natural stripes, and a pale face mask; vary approved stripe algorithm, layout, density, jitter, thickness, and mask size.
+  - **Cow Cat:** near-black head and ears, a centered continuous white face mask, and readable amber facial features; vary mask length and width without changing its position or introducing stripes.
+  - **Black Cat:** layered near-black materials, readable contrasting facial features, and no procedural markings; vary ear width and height.
+- A dark Cat-type thumbnail may use a light preview-only background, but that choice must never modify the avatar's real camera background, palette, or exported appearance.
 
 ## Model in 3D
 
@@ -21,9 +35,11 @@ Use this workflow for creating or refining a OneWorks 3D Avatar through the edit
 ## Face and pose
 
 - The face is projected onto the primary surface. Recheck eyes, nose, and mouth after changing the body, yaw, pitch, or scale.
-- Tune rounded or elliptical eyes through width, height, gap, roundness, shared rotation, and independent left/right tilt. Near tangent angles, correct foreshortening or disappearance is expected.
+- Prefer rounded-rectangle eyes for expressive character presets. Combine shared width, height, gap, and roundness with independent left/right width, height, and tilt to create tall eyes, horizontal lines, unequal rounded dots, side glances, or a vertical-plus-horizontal eye pair.
+- Give the eyes enough visual weight to carry the expression; they may be deliberately larger for alert, curious, or surprised reactions. Enable a mouth only when the expression genuinely requires one, such as an explicit smile or laugh.
+- Selecting a face preset replaces the entire previous face style. Optional asymmetric eye widths and heights must not leak into another expression or remain in its share URL.
 - Eye highlights are surface-bound details. Keep them inside the projected eye at the final pose, including when the two eyes use different heights or rotation.
-- Add a nose or mouth only when it carries identity or expression. Keep small parts large enough for the final export size.
+- Add a nose only when it carries identity or expression. Keep small parts large enough for the final export size.
 - Rotate mode controls 3D yaw and pitch. Move mode controls whole-object X/Y; pinch or wheel controls scale. Roll controls composition around the view axis. Do not use Move to hide an incorrect 3D pose.
 - The orientation control exposes red pitch and green yaw rings. Its blue and yellow affordances both manipulate the same roll state; do not describe them as separate model-roll and screen-roll values.
 - Body and face must stay attached while rotating. A sliding face is a state or renderer problem, not something to compensate for in one pose.
@@ -31,12 +47,26 @@ Use this workflow for creating or refining a OneWorks 3D Avatar through the edit
 ## Materials, lighting, and effects
 
 - A palette swatch is entity-wide. For an intentional multipart material split, preserve it and use per-part base, highlight, shadow, and foreground colors for targeted edits.
+- A constrained Cat type owns its natural palette and part-specific color relationships. Seed variation must not turn a breed into an unrelated green or fantasy palette, but preserve an unconventional color when the user deliberately chooses it.
 - Treat base, highlight, shadow, and foreground as one material system. Keep facial marks readable without making them look detached.
 - Use surface decals for blush, badges, patches, and other model-bound color shapes. Target a specific multipart part when needed; a `Body` target means the primary facial body. Rotate the model and confirm the decal stays clipped to the target silhouette and does not paint across hollow cavities.
+- Procedural coat density governs every dark marking, including forehead, eye-side, ear, and edge landmarks. `0%` removes all dark markings while preserving the independent contrasting coat patch.
+- Adjust the coat patch through `face-mask`, `ellipse`, or `rounded` shape; centered length and width; and separate vertical position. Length and width currently span `60–200%`, vertical position spans `-50..50`, and each Cat profile may narrow those ranges.
+- Generated coat markings and explicit user decals remain separate. Only an explicit conversion to editable decals should materialize generated markings and turn off the procedural pattern.
 - Lighting shades the surface; it is not a visible mesh. Leave it off for a flat material. Near light increases contrast, greater distance attenuates it, and grid density changes shading resolution rather than silhouette quality.
 - Face shadow, whole-avatar shadow, outline, and frame shadow are independent. Tune one at a time and avoid stacking all at high strength.
 - A face shadow should hug the projected surface and attenuate near tangent views. Reduce distance, softness, or opacity if it looks detached.
 - Use the outline to separate the projected silhouette from the background, not to repair contrast inside a multipart material.
+
+## Seed and composition
+
+- With no active fields or character constraints, generating a random Seed enables all currently applicable editor fields. For an active Cat profile with no enabled fields, start with its declared defaults; additional manually enabled supported fields may also vary, while profile-controlled palette, ear, and coat values stay within the profile's constrained domain.
+- Generating a new random Seed for a Cat profile always adds `scene.view.pose` if it is absent. Manually entering a Seed only re-resolves fields that are already enabled; do not treat these two actions as equivalent.
+- Manually editing one value freezes that field without clearing unrelated follow fields or silently removing the active character profile. A Cat profile must also prevent an older entity-follow binding from replacing Cat with another species.
+- The camera frame is always a manual choice. Preserve its share-URL and definition values; its public field-path identifier remains for compatibility, but never include `scene.camera.frame` in active Seed randomization and ignore that legacy follow binding in older URLs.
+- Treat `scene.view.pose` as one composition field rather than separate independent random controls. The current safe recipe keeps `positionY = 72`, `scale = 1.72`, and `roll = 0`; it varies horizontal position within `±120` and adds bounded center-facing yaw/pitch variation.
+- Compose the avatar lower in the viewport with moderate scale and deliberate bottom cropping. Avoid full-circle spins, upside-down framing, uncontrolled tilt, teleporting, and compositions that float entirely inside the frame.
+- A Seed-generated pose should interpolate smoothly for about `220 ms` while the final concrete view is immediately committed to the share URL and definition. Cancel stale movement on direct manipulation or playback and skip interpolation when reduced motion is preferred.
 
 ## Camera and transparency
 


### PR DESCRIPTION
Adds fail-closed, docs-only Avatar validation with a stable required check. Updates the Avatar authoring and debugging skill documentation and agent metadata.

Validation already completed locally: exact reviewed blobs, cached-path/OID checks, whitespace validation, and workflow YAML parsing.