### PR TITLE
docs(avatar): add guided avatar creation workflows

### DIFF
--- a/skills/oneworks-avatar/SKILL.md
+++ b/skills/oneworks-avatar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oneworks-avatar
-description: Create, refine, debug, export, and integrate editable OneWorks 3D geometric avatars. Use for avatars, mascots, bot or agent portraits, multipart 3D characters, cat breeds, character presets, expressive eyes, coat patterns, controlled Seed variation, avatar composition, OneWorks Avatar share URLs, transparent SVG or PNG, animated GIF, developer handoff, React or JavaScript integration, embed questions, @oneworks/avatar integration, or investigation of pose, projection, depth, camera, export, and animation issues. Do not use for photorealistic portraits or arbitrary raster illustration.
+description: Create, refine, debug, export, and integrate editable OneWorks 3D geometric avatars. Use for avatars, mascots, bot or agent portraits, multipart 3D characters, reference-image model design, cat breeds, character presets, expressive eyes, coat patterns, controlled Seed variation, avatar composition, OneWorks Avatar share URLs, transparent SVG or PNG, animated GIF, developer handoff, React or JavaScript integration, embed questions, @oneworks/avatar integration, or investigation of pose, projection, depth, camera, export, and animation issues. Do not use for photorealistic portraits or arbitrary raster illustration.
 ---
 
 # OneWorks Avatar
@@ -9,7 +9,9 @@ Work with the official OneWorks 3D geometric avatar system. Treat the editor URL
 
 ## Route the task
 
-- For creating, refining, or exporting an avatar, read [references/editor-workflow.md](references/editor-workflow.md). Also read [references/export-verification.md](references/export-verification.md) whenever files are requested.
+- To compose existing avatar types, character profiles, expressions, placement, or animation, read [references/editor-workflow.md](references/editor-workflow.md) and [references/preset-composition.md](references/preset-composition.md). Use this route when available models already support the requested identity, including reference images used only to communicate mood or composition.
+- To design an original editable 3D character from a reference image, sketch, mascot, or new silhouette, read [references/editor-workflow.md](references/editor-workflow.md) and [references/reference-modeling.md](references/reference-modeling.md). Translate distinguishing features into actual supported geometry, materials, and model-bound details.
+- For any requested exported file, also read [references/export-verification.md](references/export-verification.md).
 - For developer integration, read [references/developer-integration.md](references/developer-integration.md). Read it before recommending npm, React, Vue, JavaScript, Web Components, iframe, embed, JSON, or runtime APIs so package and product boundaries stay accurate.
 - For editor implementation or debugging, read [references/3d-debugging.md](references/3d-debugging.md). Also read the workflow or export reference when the bug touches those surfaces.
 - For a request spanning routes, read each applicable reference once and keep one shared source of truth for the scene.

--- a/skills/oneworks-avatar/references/preset-composition.md
+++ b/skills/oneworks-avatar/references/preset-composition.md
@@ -1,0 +1,81 @@
+# Compose an avatar from existing models
+
+Use this guide when the user wants a recognizable existing character, a particular emotion, a clean avatar composition, or a finished animation without designing a new model. Read it together with [editor-workflow.md](editor-workflow.md).
+
+## Translate the request into an editing brief
+
+Identify five concrete decisions before touching the editor:
+
+1. **Identity:** existing avatar type, optional supported character profile, natural palette, and recognizable features.
+2. **Expression:** the intended feeling, whether a nose matters, and whether a mouth is genuinely necessary.
+3. **Composition:** front-facing or gently turned, horizontal placement, lower-edge crop, size, and available headroom.
+4. **Variation:** which values should follow Seed and which authored features must stay fixed.
+5. **Delivery:** editable link, static image, animated asset, background, frame, and output dimensions.
+
+Treat a supplied editor link as the starting scene. Preserve every choice the user did not ask to change. A mood board or example screenshot may communicate expression or framing without requiring a newly modeled character.
+
+## Choose the closest supported identity
+
+- Select the base avatar type first: cloud, sun, cat, dog, bear, rabbit, or bun. Changing the entity later can replace authored shape, face, materials, pose, and camera settings.
+- Keep **Avatar type**, **Cat type**, and **Saved looks** distinct. A saved look restores an entire scene; a Cat type constrains one recognizable character within the Cat entity.
+- Cat currently supports Siamese, British Shorthair, Russian Blue, Orange Tabby, Cow Cat, and Black Cat. Pick the closest profile before adjusting its expression.
+- Dog, bear, rabbit, and the other existing entities do not currently expose an equivalent breed-profile or procedural-coat selector. Use their actual existing models and editable materials; do not promise a Husky, Corgi, panda, or rabbit breed button that does not exist.
+- If an available model is structurally right but needs a different expression, material, or framing, stay in this composition workflow. Move to [reference-modeling.md](reference-modeling.md) only when the requested identity needs genuinely different editable geometry or model-bound features.
+- Selecting an already-active Cat type removes its profile constraint while preserving the concrete appearance. Do not confuse removing that constraint with deleting the avatar.
+
+## Build expression primarily with the eyes
+
+Start from the closest face preset, then adjust its real rounded-rectangle eye geometry. If the compact preset row does not show enough options, open its **More** control instead of assuming the expression is unavailable.
+
+| Intended feeling         | Eye construction                                                                                    | Mouth guidance                                                    |
+| ------------------------ | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Angry or determined      | Narrow rounded bars, inward opposing tilts, slightly tighter spacing.                               | Leave off unless the user asks for an overt snarl.                |
+| Happy or friendly        | Open, generous rounded eyes with relaxed or gently opposing tilts.                                  | Add a smile only when an explicit smile is part of the request.   |
+| Sleepy or unimpressed    | Two short, thin, almost horizontal rounded bars.                                                    | Leave off; the eyes should carry the mood.                        |
+| Surprised or alert       | Larger open rounded rectangles or an intentionally unequal pair.                                    | Leave off unless the requested reaction clearly needs it.         |
+| Curious or skeptical     | Different left/right heights or widths, a slight directional tilt, and thoughtful spacing.          | Leave off; use asymmetry rather than a generic grin.              |
+| Playful or winking       | One open eye and one near-horizontal rounded bar.                                                   | Optional only when the brief explicitly asks for a playful smile. |
+| Focused or side-glancing | Slim rounded eyes sharing a direction or subtle matching tilt.                                      | Usually leave off.                                                |
+| Mixed or quirky          | One taller vertical rounded eye and one wider horizontal rounded eye, using independent dimensions. | Usually leave off.                                                |
+| Large-and-small dots     | Independently sized, highly rounded left and right eyes.                                            | Leave off unless necessary.                                       |
+
+Keep eyes large enough to remain legible at the final export size. Use real independent left/right width, height, and tilt rather than faking a shape with unrelated overlays. Selecting a face preset replaces the complete previous face style; old asymmetric settings should not leak into the next expression.
+
+A nose is optional: keep it when it supports the animal's identity, and remove it when the simpler face reads better. A mouth is an accent, not the default mechanism for every emotion.
+
+## Compose the avatar as a portrait
+
+- Establish composition in **Camera** mode, because the editing canvas can show geometry outside the actual exported frame.
+- Start with a moderately sized character placed lower in the viewport. Let the lower edge crop a little of the body while leaving useful breathing room above the ears.
+- For a centered portrait, keep the face readable and use only a restrained yaw or pitch. For a left- or right-peeking portrait, offset horizontally while keeping the face oriented toward the center.
+- Preserve ear tips, eyes, and other key identity features unless the user deliberately asks for a tighter crop.
+- Avoid a character floating entirely inside the frame, extreme face-filling scale, uncontrolled tilt, upside-down composition, or full-circle spins unless the user explicitly requests them.
+- Distinguish actual camera background from a light preview-only background used to make a dark breed thumbnail visible. Thumbnail contrast must not silently change the scene.
+- Choose a background with enough separation from dark fur, white fur, or dark facial marks. Keep a user-selected square, rounded, or circular frame unchanged.
+
+## Apply meaningful controlled variation
+
+- Randomness should vary only features appropriate to the character and the user's request. Manually authored identity, species, breed-defining color relationships, and fixed markings remain stable.
+- Siamese may vary the size of its centered dark muzzle while preserving cream fur, chocolate ears, muzzle position, and the absence of stripes.
+- British Shorthair may vary restrained marking density and mask size; Russian Blue and Black Cat may vary ear dimensions without introducing procedural markings.
+- Orange Tabby may vary its approved warm-natural stripe pattern and face-mask size; Cow Cat may vary its centered white-mask size without losing its black-and-white identity.
+- With no active fields or profile constraints, generating a random Seed activates the applicable editor fields. A selected Cat profile instead limits variation to its supported defaults and any additional permitted fields the user enables.
+- Manual edits freeze only the changed field. Preserve other enabled follow fields and the active character profile.
+- The camera frame is always manually selected and never participates in Seed randomization. View pose is one supported follow field with bounded, composed movement; it must not become uncontrolled spinning.
+
+## Pick motion after the static scene works
+
+- Use Idle, Blink, Listening, Thinking, Working, or Nod for an ambient assistant.
+- Use Wink or Playful for a lighthearted reaction; use Happy, Angry, Surprised, Excited, or Celebrate when the user explicitly requests that mood.
+- Confirm animation keeps the chosen body, palette, profile identity, face readability, and composition. Set Once or Loop according to the intended product behavior.
+- Preview the actual selected animation before GIF export. Do not substitute a still image or fabricate motion from screenshots.
+
+## Practical examples
+
+**"An angry orange cat for a support agent."** Select Cat, then Orange Tabby. Choose inward-tilted narrow rounded eyes, omit the mouth, preserve warm fur and paired tabby stripes, compose the head low in the camera, and enable only approved pattern variation.
+
+**"A happy Siamese avatar that stays recognizable when randomized."** Select Cat, then Siamese. Keep the cream head, chocolate ears, centered dark elliptical muzzle, fixed muzzle position, and stripe-free face. Use open friendly rounded eyes; vary muzzle size and permitted framing without changing its breed palette.
+
+**"A thoughtful dog looking in from the right."** Select the existing Dog entity. Use gently asymmetric focused eyes and an optional Listening or Thinking animation, place the character toward the right while facing inward, and preserve its authored ear geometry. Do not claim a dog-breed selector or unsupported procedural dog coat.
+
+Deliver the final editable URL and, when requested, the verified export described in [export-verification.md](export-verification.md).

--- a/skills/oneworks-avatar/references/reference-modeling.md
+++ b/skills/oneworks-avatar/references/reference-modeling.md
@@ -1,0 +1,97 @@
+# Design an editable 3D avatar from a reference
+
+Use this guide when a supplied photo, illustration, sketch, mascot, or character description calls for a distinct editable avatar rather than merely selecting an existing expression. Read it together with [editor-workflow.md](editor-workflow.md).
+
+The deliverable is a real OneWorks 3D scene: editable geometry, actual part materials, surface-bound details, a restorable scene, and the normal export pipeline. It is not a traced screenshot, image-generated illustration, flat SVG redraw, or photorealistic portrait.
+
+## Decide whether a new model is actually needed
+
+- If the reference only communicates "happier," "more curious," "slightly lower," or "like this existing Siamese," use [preset-composition.md](preset-composition.md).
+- If the image changes the recognizable silhouette, ear construction, body structure, marking placement, or part-specific material relationships, continue with this modeling workflow.
+- Select the closest existing base entity when its real structure already matches the subject. Use custom or multipart geometry only when it materially improves the requested identity.
+- Do not present an unsupported breed profile, Seed constraint, primitive, or public integration API as already implemented. Ask for a product implementation only if the user explicitly requests development beyond the existing editor.
+
+## Extract the character's visual signature
+
+Inspect the supplied reference and separate identity-critical features from incidental photographic details:
+
+1. **Primary silhouette:** head proportions, cheek width, taper, body fullness, and overall shape language.
+2. **Attachments:** ear count, ear angle, pointed versus floppy shape, attachment location, insertion depth, and left/right balance.
+3. **Distinctive regions:** muzzle, eye mask, ear tips, forehead blaze, chest patch, stripes, or other recognizable markings.
+4. **Material hierarchy:** dominant base color, secondary region color, highlight, shadow, and readable facial foreground.
+5. **Expression:** eye size, orientation, asymmetry, distance, nose relevance, and whether a mouth contributes anything essential.
+6. **Composition:** inward-facing pose, scale, portrait crop, background contrast, and how much of the character extends below the frame.
+7. **Allowed variation:** which characteristics define the identity, which may change across Seeds, and which values the user explicitly fixed.
+
+Ignore irrelevant camera noise, image compression, incidental scenery, and tiny textures that will disappear at avatar size. Preserve the recognizable idea without promising a photographic replica.
+
+## Translate reference features into real geometry
+
+Build the primary volume first, then add only the parts necessary to communicate the subject.
+
+| Reference feature                 | Preferred existing construction                                                     |
+| --------------------------------- | ----------------------------------------------------------------------------------- |
+| Round or softly oval head         | Sphere or ellipse with deliberate local width, height, and depth.                   |
+| Broad cheeks or a tapered head    | Ellipse, rounded trapezoid, or another supported softened primary volume.           |
+| Pointed upright ears              | Rounded cone, half-cone, or supported tapered attachment with real local depth.     |
+| Long upright ears                 | Capsule or tapered attachment positioned in the primary body's local space.         |
+| Floppy dog ears                   | Teardrop, capsule, or softened tapered attachment using its actual local rotation.  |
+| Rounded bear or panda ears        | Small ellipse or other supported rounded attachment with independent material.      |
+| Centered muzzle or chest bib      | An existing procedural face patch where supported, or a real primary-surface decal. |
+| Paired eye masks or cheek patches | Separate surface-projected decals anchored to the appropriate target part.          |
+| Contrasting ears or ear tips      | Actual per-part materials or supported part-targeted decals.                        |
+| Horns or short spikes             | Cone, frustum, or other supported tapered volume, not a screen-space triangle.      |
+| Expressive eyes                   | Rounded rectangular face geometry with independent left/right size and tilt.        |
+
+Use only shapes and controls genuinely available in the editor. If an exact form is unavailable, choose the closest supported editable construction and state the limitation instead of drawing a fake replacement over the scene.
+
+## Construct parts in local 3D space
+
+- Width, height, and depth belong to each part's local X, Y, and Z scale. Set believable depth before judging the silhouette.
+- Apply each part's own rotation and placement before the whole entity's yaw, pitch, or roll. Ears, horns, rays, and other attachments must remain attached when the avatar turns.
+- Let actual rotated depth and the existing renderer determine near/far ordering. Do not manually reorder visible SVG fragments to make one screenshot appear correct.
+- Use face occlusion for pieces physically inserted into the main facial surface, such as ear roots. Do not hollow out broad pieces that should merge into one continuous silhouette.
+- Keep mirrored attachment families coherent while allowing deliberate small asymmetry. Match the reference's attachment relationship rather than copying isolated screen coordinates.
+- Preview both the requested pose and a nearby restrained yaw or pitch. A marking or attachment that floats, slides, or crosses an unintended silhouette needs a local-geometry or target-surface correction.
+
+## Keep materials and markings anatomically coherent
+
+- Treat base, highlight, shadow, and foreground as one coordinated material system. Facial marks must remain readable against the actual part beneath them.
+- Start with a shared palette when the animal is mostly uniform. Use per-part materials for deliberate splits such as a cream face with dark ears or a white face with black ears.
+- Preserve existing part-specific materials when refining a single feature; reapplying an entity-wide palette can erase the very relationship that defines the character.
+- Anchor patches and markings to real model surfaces. A centered muzzle stays on the primary face; a paired cheek patch follows its cheek; an ear detail targets the ear.
+- Rotate the avatar slightly and confirm each detail remains projected, clipped to the intended silhouette, and visually attached. Do not add a detached overlay that only aligns in one front-facing pose.
+- Use the existing Cat procedural-coat and Cat-profile systems only for the Cat entity. Other animals can use their actual editable parts, materials, and supported surface decals; they do not currently gain custom breed profiles or procedural coats merely because a reference image suggests one.
+- Preserve natural color relationships when realism is requested. Respect fantasy colors only when the user deliberately asks for them.
+
+## Decide what is fixed and what may vary
+
+Classify every important feature before enabling Seed:
+
+- **Identity-fixed:** species, structural silhouette, distinguishing ear material, breed-defining color relationship, required patch anchor, and intentionally selected camera frame.
+- **User-fixed:** any explicit expression, background, crop, size, or manual adjustment the user requested not to change.
+- **Safely variable:** supported ear dimensions, a Cat profile's approved marking or patch-size domain, selected facial expressions, background, or the single bounded view-pose field when permitted.
+- **Not currently supported:** a new species-specific breed selector, a new procedural coat family, or a custom public Seed domain that the existing editor does not expose.
+
+For an existing Cat profile, remain inside its declared palette and field domains. For a custom animal, enable only controls the current editor actually supports; do not invent a profile contract to justify unrestricted randomization.
+
+## Reference-driven construction examples
+
+**Siamese reference.** Begin with the existing Siamese Cat profile when available. Keep the cream primary head, genuinely chocolate-colored ear parts, centered dark elliptical muzzle at its fixed vertical offset, and stripe-free face. Express variation through approved muzzle dimensions rather than moving its identifying mask.
+
+**Panda-like reference.** Begin with Bear if its underlying head and ear arrangement fit. Keep a light primary face, independently dark rounded ear parts, and two actual surface-bound dark eye patches. Preserve face and ear contrast without claiming that a Panda breed button exists.
+
+**Fox-like reference.** Choose an existing Cat-like structure or a custom multipart body according to the desired silhouette. Build a warm-orange tapered head, true pointed ear attachments, and a light muzzle anchored to the facial surface. Use actual per-part ear materials; do not invent a Fox profile or flatten the model into a logo.
+
+**Floppy-eared dog reference.** Start with the existing Dog entity when possible. Shape its real ear attachments with supported softened geometry and local rotations, retain the requested fur colors through per-part materials, and add only genuinely supported model-bound patches. Do not advertise an unimplemented dog-breed or procedural dog-coat picker.
+
+**Black-and-white cow-cat reference.** Use the existing Cow Cat profile when its true geometry matches. Keep the dark head and ears, continuous centered white facial mask, readable warm foreground, and stripe-free coat. Vary mask size only within the profile's supported domain.
+
+## Verify the editable result
+
+1. Confirm the silhouette reads correctly from the intended camera crop and that critical ears, eyes, and muzzle are recognizable.
+2. Slightly adjust yaw or pitch and verify attachments, markings, and face projection continue to follow the underlying model.
+3. Check front/back depth, per-part materials, foreground contrast, and the absence of accidental hollow overlaps or detached decals.
+4. Test only the requested supported Seed fields; confirm fixed identity features and the manually chosen camera frame remain unchanged.
+5. Reload the final editor URL and confirm it restores the same concrete scene, including the intended geometry and user-fixed settings.
+6. If a file is requested, follow [export-verification.md](export-verification.md) and verify the real exported asset rather than repairing a screenshot afterward.


### PR DESCRIPTION
## Summary
- Add guided documentation for the two Avatar creation routes: preset composition and reference modeling.
- Keep the existing SDK, debugging, and export workflows documented and available.

## Scope
Documentation only; no product or runtime files changed.