### PR TITLE
fix: keep avatar carousel wrapping on repeated left navigation

### DIFF
--- a/__tests__/HomePage.spec.tsx
+++ b/__tests__/HomePage.spec.tsx
@@ -85,6 +85,28 @@ describe('HomePage calls to action', () => {
   })
 })
 
+describe('HomePage carousel navigation', () => {
+  it('keeps wrapping when navigating backward through multiple complete loops', async () => {
+    await renderHomePage('en')
+    const carousel = host.querySelector<HTMLElement>('.avatar-home__carousel-shell')
+
+    expect(carousel).not.toBeNull()
+
+    for (let step = 0; step < 18; step += 1) {
+      act(() => {
+        carousel?.dispatchEvent(new KeyboardEvent('keydown', {
+          bubbles: true,
+          key: 'ArrowLeft'
+        }))
+      })
+
+      expect(host.querySelector('.avatar-home__carousel-shell')).not.toBeNull()
+    }
+
+    expect(host.querySelector('[role="tab"][aria-selected="true"]')?.getAttribute('aria-label')).toBe('Dog')
+  })
+})
+
 describe('random editor query', () => {
   it('persists the supplied seed and every supported seeded field', () => {
     const query = createRandomAvatarEditorQuery(

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -17,7 +17,7 @@ interface HomePageProps {
 }
 
 const getWrappedIndex = (index: number) => (
-  (index + HOME_TEMPLATES.length) % HOME_TEMPLATES.length
+  ((index % HOME_TEMPLATES.length) + HOME_TEMPLATES.length) % HOME_TEMPLATES.length
 )
 
 const CAROUSEL_OFFSETS = [-3, -2, -1, 0, 1, 2, 3] as const


### PR DESCRIPTION
Fixes the Avatar home carousel crash after repeated left navigation by using Euclidean modulo for negative indices.

- Adds an 18-left-navigation regression test.
- Prior independent review reported 205 tests, typecheck, and actual browser 24-left navigation passing.

Scope is limited to the carousel wrap calculation and its regression coverage.