### PR TITLE
ci: cancel stale Avatar checks and reuse dependency cache

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -12,6 +12,10 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+concurrency:
+  group: avatar-sdk-ci-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.event_name, github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   sdk:
     name: build-test-pack
@@ -302,6 +306,10 @@ jobs:
         with:
           node-version-file: app-source/.node-version
           registry-url: https://registry.npmjs.org
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            app-source/pnpm-lock.yaml
 
       - name: Install dependencies
         if: steps.scope.outputs.scope != 'documentation'


### PR DESCRIPTION
## Summary

- Cancel only superseded pull request SDK checks; preserve every main-push and manual validation.
- Cache pnpm dependencies using both the Avatar lockfile and the checked-out app-source lockfile.
- Preserve the protected build-test-pack check, zero-install documentation fast path, and all SDK/security checks.

## Validation

- Independent workflow review: PASS.
- Ruby Psych YAML parsing and focused event/cache contract assertions: PASS.
- Repository diff validation: PASS.

## Experience Review

- [x] 已判断是否需要沉淀经验
- [x] 如需要，已运行 `$post-task-experience-review`
- [x] reviewer `PASS` / `NOT APPLICABLE` 后才进入 merge

## Policy Conflict Review

- [x] Protected check identity, documentation fast path, main-push coverage, and least-privilege permissions are unchanged.
