### PR TITLE
ci: avoid duplicate post-merge SDK validation

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -2,8 +2,6 @@ name: Avatar SDK CI
 
 on:
   pull_request:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/__tests__/sdkCiWorkflow.spec.ts
+++ b/__tests__/sdkCiWorkflow.spec.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+const workflowPath = new URL('../.github/workflows/sdk-ci.yml', import.meta.url)
+
+describe('Avatar SDK CI workflow', () => {
+  it('validates pull-request integration trees once and retains a full manual path', () => {
+    const workflow = readFileSync(workflowPath, 'utf8')
+
+    expect(workflow).toMatch(/^on:\n  pull_request:\n  workflow_dispatch:/mu)
+    expect(workflow).not.toMatch(/^  push:/mu)
+    expect(workflow).toContain('name: build-test-pack')
+    expect(workflow).toContain("if [[ \"$EVENT_NAME\" != workflow_dispatch ]]")
+    expect(workflow).toContain('scope=full')
+    expect(workflow).toContain("steps.scope.outputs.scope != 'documentation'")
+  })
+})


### PR DESCRIPTION
## Summary

This efficiency-only change removes the automatic `push` trigger for `main` from Avatar SDK CI. The same identical-tree PR run already validates the merge candidate, while the post-merge push run repeats the full SDK validation.

Observed behavior was approximately 12 runner minutes for the identical-tree PR run and approximately 11 runner minutes for the post-merge push run, for an expected saving of about 11 runner minutes per merge.

## Preserved behavior

- The required `build-test-pack` PR integration check remains enabled.
- `workflow_dispatch` retains the full validation path.
- Existing validation steps and manual full-scope behavior are unchanged.
- Added a Vitest contract test covering the trigger and preserved workflow behavior.

## Scope

No permissions, source-trust, release, deployment, or security changes are included.