### PR TITLE
chore: publish Avatar SDK 1.0.0-rc.7

### DIFF
--- a/__tests__/avatarSdkProvenance.spec.ts
+++ b/__tests__/avatarSdkProvenance.spec.ts
@@ -5,12 +5,12 @@ import { describe, expect, it } from 'vitest'
 import { verifyAvatarSdkAttestations } from '../scripts/avatar-sdk-provenance.mjs'
 
 const name = '@oneworks/avatar'
-const version = '1.0.0-rc.6'
+const version = '1.0.0-rc.7'
 const sourceSha = '0998f9d6266d71c757ab8956b8fba0b92c3226e2'
 const bytes = Buffer.from('approved avatar sdk tarball')
 const integrity = `sha512-${createHash('sha512').update(bytes).digest('base64')}`
 const digest = createHash('sha512').update(bytes).digest('hex')
-const subject = [{ name: 'pkg:npm/%40oneworks/avatar@1.0.0-rc.6', digest: { sha512: digest } }]
+const subject = [{ name: 'pkg:npm/%40oneworks/avatar@1.0.0-rc.7', digest: { sha512: digest } }]
 
 const encode = (payload: unknown) => Buffer.from(JSON.stringify(payload)).toString('base64')
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneworks/avatar-assets",
   "type": "module",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "packageManager": "pnpm@11.7.0",
   "private": true,
   "description": "OneWorks geometric 3D Avatar editor, runtime, and framework adapters",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneworks/avatar",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "description": "Framework-neutral OneWorks 3D Avatar definitions, catalog, and animation runtime",
   "type": "module",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneworks/avatar-react",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "description": "React renderer and embeddable editor for OneWorks 3D Avatar",
   "type": "module",
   "license": "MIT",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneworks/avatar-vue",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "description": "Vue renderer and embeddable editor for OneWorks 3D Avatar",
   "type": "module",
   "license": "MIT",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneworks/avatar-web",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "description": "Vanilla JavaScript runtime, editor mounts, and Web Components for OneWorks 3D Avatar",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- align all Avatar SDK package manifests to 1.0.0-rc.7
- update provenance contract fixture for rc.7

## Validation
- targeted workflow/provenance tests
- pnpm typecheck:sdk
- pnpm smoke:sdk
- immutable tarball prepare dry run
- git diff --check