### PR TITLE
ci: reuse validated npm publish artifacts

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,6 +21,10 @@ on:
         options:
           - oidc
           - token
+      candidate_run_id:
+        description: Reuse immutable tarballs from this exact successful publish-validation run.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -33,8 +37,77 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    name: publish-preflight
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: npm-publish
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    outputs:
+      candidate_run_id: ${{ steps.candidate.outputs.run_id }}
+      reuse_candidate: ${{ steps.candidate.outputs.reuse_candidate }}
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout requested source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Require protected main and configured publishing authentication
+        env:
+          AUTH_MODE: ${{ inputs.auth_mode }}
+          NODE_AUTH_TOKEN: ${{ inputs.auth_mode == 'token' && secrets.NPM_TOKEN || '' }}
+          TRUSTED_PUBLISHERS: ${{ vars.NPM_TRUSTED_PUBLISHERS }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/main'
+          if [ "$AUTH_MODE" = 'oidc' ]; then
+            test "$TRUSTED_PUBLISHERS" = '@oneworks/avatar,@oneworks/avatar-react,@oneworks/avatar-web,@oneworks/avatar-vue|oneworks-ai/avatar|npm-publish.yml|npm-publish|allow:npm-publish|token:none'
+          else
+            test "$AUTH_MODE" = 'token'
+            test -n "$NODE_AUTH_TOKEN"
+          fi
+
+      - name: Resolve one SDK release version
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(node -e "const fs=require('fs'); const files=['packages/avatar/package.json','packages/react/package.json','packages/web/package.json','packages/vue/package.json']; const versions=[...new Set(files.map(file=>JSON.parse(fs.readFileSync(file)).version))]; if(versions.length!==1) process.exit(1); process.stdout.write(versions[0])")"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify candidate validation evidence
+        id: candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+          SOURCE_SHA: ${{ github.sha }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CANDIDATE_RUN_ID" ]; then
+            echo 'reuse_candidate=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          [[ "$CANDIDATE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$CANDIDATE_RUN_ID" > run.json
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$CANDIDATE_RUN_ID/jobs?per_page=100" > jobs.json
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$CANDIDATE_RUN_ID/artifacts?per_page=100" > artifacts.json
+          gh api "repos/$GITHUB_REPOSITORY/actions/workflows/npm-publish.yml" > workflow.json
+          node scripts/verify-npm-publish-candidate.mjs run.json jobs.json artifacts.json workflow.json
+          echo "run_id=$CANDIDATE_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo 'reuse_candidate=true' >> "$GITHUB_OUTPUT"
+
   validate:
     name: test-pack-validate
+    needs: preflight
+    if: ${{ always() && (inputs.dry_run || (needs.preflight.result == 'success' && needs.preflight.outputs.reuse_candidate != 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -92,17 +165,47 @@ jobs:
           name: avatar-sdk-${{ steps.publish.outputs.version }}
           path: ${{ runner.temp }}/avatar-sdk-tarballs
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
+
+  reuse-candidate:
+    name: verify-candidate-tarballs
+    needs: preflight
+    if: ${{ always() && !inputs.dry_run && needs.preflight.result == 'success' && needs.preflight.outputs.reuse_candidate == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout requested source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download candidate immutable npm tarballs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: avatar-sdk-${{ needs.preflight.outputs.version }}
+          path: ${{ runner.temp }}/avatar-sdk-tarballs
+          run-id: ${{ needs.preflight.outputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify candidate source, version, and package integrities
+        env:
+          NPM_PUBLISH_TARBALL_DIRECTORY: ${{ runner.temp }}/avatar-sdk-tarballs
+        run: node scripts/publish-sdk-packages.mjs --verify-prepared
 
   publish:
     name: npm-publish-verify
-    needs: validate
-    if: ${{ !inputs.dry_run }}
+    needs: [preflight, validate, reuse-candidate]
+    if: ${{ always() && !inputs.dry_run && needs.preflight.result == 'success' && ((needs.validate.result == 'success' && needs['reuse-candidate'].result == 'skipped') || (needs.validate.result == 'skipped' && needs['reuse-candidate'].result == 'success')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:
       name: npm-publish
     permissions:
+      actions: read
       contents: read
       id-token: write
     outputs:
@@ -126,23 +229,15 @@ jobs:
       - name: Download immutable npm tarballs
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: avatar-sdk-${{ needs.validate.outputs.version }}
+          name: avatar-sdk-${{ needs.preflight.outputs.version }}
           path: ${{ runner.temp }}/avatar-sdk-tarballs
+          run-id: ${{ needs.preflight.outputs.candidate_run_id || github.run_id }}
+          github-token: ${{ github.token }}
 
-      - name: Require protected main for publishing
+      - name: Verify downloaded immutable npm tarballs
         env:
-          AUTH_MODE: ${{ inputs.auth_mode }}
-          NODE_AUTH_TOKEN: ${{ inputs.auth_mode == 'token' && secrets.NPM_TOKEN || '' }}
-          TRUSTED_PUBLISHERS: ${{ vars.NPM_TRUSTED_PUBLISHERS }}
-        run: |
-          set -euo pipefail
-          test "$GITHUB_REF" = 'refs/heads/main'
-          if [ "$AUTH_MODE" = 'oidc' ]; then
-            test "$TRUSTED_PUBLISHERS" = '@oneworks/avatar,@oneworks/avatar-react,@oneworks/avatar-web,@oneworks/avatar-vue|oneworks-ai/avatar|npm-publish.yml|npm-publish|allow:npm-publish|token:none'
-          else
-            test "$AUTH_MODE" = 'token'
-            test -n "$NODE_AUTH_TOKEN"
-          fi
+          NPM_PUBLISH_TARBALL_DIRECTORY: ${{ runner.temp }}/avatar-sdk-tarballs
+        run: node scripts/publish-sdk-packages.mjs --verify-prepared
 
       - name: Create isolated npm configuration
         env:

--- a/__tests__/npmPublishCandidate.spec.ts
+++ b/__tests__/npmPublishCandidate.spec.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import { verifyNpmPublishCandidate } from '../scripts/verify-npm-publish-candidate.mjs'
+
+const sourceSha = '0998f9d6266d71c757ab8956b8fba0b92c3226e2'
+const version = '1.0.0-rc.7'
+
+const shouldPublish = ({
+  dryRun,
+  preflight,
+  reuseCandidate,
+  validate
+}: {
+  dryRun: boolean
+  preflight: string
+  reuseCandidate: string
+  validate: string
+}) => !dryRun && preflight === 'success' && (
+  (validate === 'success' && reuseCandidate === 'skipped') ||
+  (validate === 'skipped' && reuseCandidate === 'success')
+)
+
+const workflowJobs = () => JSON.parse(execFileSync('ruby', [
+  '-ryaml',
+  '-rjson',
+  '-e',
+  'workflow = YAML.load_file(ARGV.fetch(0)); puts JSON.generate(workflow.fetch("jobs").transform_values { |job| job.slice("needs", "if", "permissions") })',
+  new URL('../.github/workflows/npm-publish.yml', import.meta.url).pathname
+], { encoding: 'utf8' }))
+
+const evidence = () => ({
+  artifacts: [{
+    expired: false,
+    name: `avatar-sdk-${version}`,
+    workflow_run: { id: 123 }
+  }],
+  jobs: [{ conclusion: 'success', name: 'test-pack-validate', status: 'completed' }],
+  run: {
+    conclusion: 'success',
+    event: 'workflow_dispatch',
+    head_branch: 'main',
+    head_sha: sourceSha,
+    id: 123,
+    repository: { full_name: 'oneworks-ai/avatar' },
+    status: 'completed',
+    workflow_id: 456
+  },
+  sourceSha,
+  version,
+  workflow: { id: 456, path: '.github/workflows/npm-publish.yml' }
+})
+
+describe('npm publish recovery candidate', () => {
+  it('accepts an exact successful validation artifact even when a later publish job failed', () => {
+    const value = evidence()
+    value.run.conclusion = 'failure'
+    expect(verifyNpmPublishCandidate(value).name).toBe(`avatar-sdk-${version}`)
+  })
+
+  it('accepts only the exact successful validation artifact', () => {
+    expect(verifyNpmPublishCandidate(evidence()).name).toBe(`avatar-sdk-${version}`)
+  })
+
+  it.each([
+    ['wrong repository', (value: any) => { value.run.repository.full_name = 'oneworks-ai/app' }],
+    ['wrong SHA', (value: any) => { value.run.head_sha = 'a'.repeat(40) }],
+    ['wrong workflow', (value: any) => { value.workflow.path = '.github/workflows/other.yml' }],
+    ['non-dispatch event', (value: any) => { value.run.event = 'push' }],
+    ['non-main head branch', (value: any) => { value.run.head_branch = 'recovery' }],
+    ['cancelled workflow run', (value: any) => { value.run.conclusion = 'cancelled' }],
+    ['timed out workflow run', (value: any) => { value.run.conclusion = 'timed_out' }],
+    ['action-required workflow run', (value: any) => { value.run.conclusion = 'action_required' }],
+    ['failed validation job', (value: any) => { value.jobs[0].conclusion = 'failure' }],
+    ['expired artifact', (value: any) => { value.artifacts[0].expired = true }],
+    ['artifact missing an expiration state', (value: any) => { delete value.artifacts[0].expired }],
+    ['artifact with null expiration state', (value: any) => { value.artifacts[0].expired = null }],
+    ['duplicate artifact', (value: any) => { value.artifacts.push({ ...value.artifacts[0] }) }],
+    ['artifact from another run', (value: any) => { value.artifacts[0].workflow_run.id = 999 }],
+    ['wrong artifact version', (value: any) => { value.artifacts[0].name = 'avatar-sdk-0.0.0' }]
+  ])('fails closed for %s', (_name, mutate) => {
+    const value = evidence()
+    mutate(value)
+    expect(() => verifyNpmPublishCandidate(value)).toThrow(/Unsafe npm publish candidate/u)
+  })
+
+  it('keeps dry runs on the full validation path and guards real publishing before it', () => {
+    const jobs = workflowJobs()
+    const workflow = readFileSync(new URL('../.github/workflows/npm-publish.yml', import.meta.url), 'utf8')
+    expect(workflow).toContain('candidate_run_id:')
+    expect(workflow).toContain('Require protected main and configured publishing authentication')
+    expect(workflow).toContain("test \"$GITHUB_REF\" = 'refs/heads/main'")
+    expect(workflow).toContain("test -n \"$NODE_AUTH_TOKEN\"")
+    expect(workflow).toContain("test \"$TRUSTED_PUBLISHERS\" = '@oneworks/avatar")
+    expect(workflow).toContain('node scripts/verify-npm-publish-candidate.mjs')
+    expect(workflow).toContain('node scripts/publish-sdk-packages.mjs --verify-prepared')
+    expect(workflow).toContain('retention-days: 7')
+    expect(jobs.validate.needs).toBe('preflight')
+    expect(jobs.validate.if).toContain('always()')
+    expect(jobs.validate.if).toContain('inputs.dry_run')
+    expect(jobs['reuse-candidate'].needs).toBe('preflight')
+    expect(jobs['reuse-candidate'].if).toContain('always()')
+    expect(jobs.publish.needs).toEqual(['preflight', 'validate', 'reuse-candidate'])
+    expect(jobs.publish.if).toContain('always()')
+    expect(jobs.publish.if).toContain("needs.validate.result == 'success'")
+    expect(jobs.publish.if).toContain("needs['reuse-candidate'].result == 'success'")
+    expect(jobs.publish.permissions).toMatchObject({ actions: 'read', contents: 'read', 'id-token': 'write' })
+  })
+
+  it.each([
+    ['dry run after skipped preflight', { dryRun: true, preflight: 'skipped', reuseCandidate: 'skipped', validate: 'success' }, false],
+    ['normal validation', { dryRun: false, preflight: 'success', reuseCandidate: 'skipped', validate: 'success' }, true],
+    ['candidate validation', { dryRun: false, preflight: 'success', reuseCandidate: 'success', validate: 'skipped' }, true],
+    ['both paths ran', { dryRun: false, preflight: 'success', reuseCandidate: 'success', validate: 'success' }, false],
+    ['both paths skipped', { dryRun: false, preflight: 'success', reuseCandidate: 'skipped', validate: 'skipped' }, false],
+    ['failed preflight', { dryRun: false, preflight: 'failure', reuseCandidate: 'skipped', validate: 'skipped' }, false],
+    ['failed candidate verification', { dryRun: false, preflight: 'success', reuseCandidate: 'failure', validate: 'skipped' }, false]
+  ])('publishes only for the complete needs contract: %s', (_name, state, expected) => {
+    expect(shouldPublish(state)).toBe(expected)
+  })
+})

--- a/__tests__/publishSdkPackagesArtifact.spec.ts
+++ b/__tests__/publishSdkPackagesArtifact.spec.ts
@@ -1,0 +1,132 @@
+import { createHash } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const root = new URL('..', import.meta.url).pathname
+const script = new URL('../scripts/publish-sdk-packages.mjs', import.meta.url).pathname
+const directories: string[] = []
+const sourceSha = '0998f9d6266d71c757ab8956b8fba0b92c3226e2'
+const version = JSON.parse(readFileSync(join(root, 'packages/avatar/package.json'), 'utf8')).version
+
+const temporaryDirectory = () => {
+  const directory = mkdtempSync(join(tmpdir(), 'avatar-publish-artifact-'))
+  directories.push(directory)
+  return directory
+}
+
+const fingerprint = (directory: string) => Object.fromEntries(
+  ['avatar-sdk-candidate.json', `oneworks-avatar-${version}.tgz`, `oneworks-avatar-react-${version}.tgz`, `oneworks-avatar-vue-${version}.tgz`, `oneworks-avatar-web-${version}.tgz`]
+    .map(name => {
+      const file = join(directory, name)
+      return [name, {
+        hash: createHash('sha512').update(readFileSync(file)).digest('hex'),
+        mtimeMs: statSync(file).mtimeMs
+      }]
+    })
+)
+
+const createFakePackageTools = () => {
+  const directory = temporaryDirectory()
+  writeFileSync(join(directory, 'pnpm'), `#!/usr/bin/env node
+const { execFileSync } = require('node:child_process')
+const { mkdtempSync, readFileSync, writeFileSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const { join } = require('node:path')
+const args = process.argv.slice(2)
+if (args[0] === 'build:sdk') process.exit(0)
+const names = {
+  '@oneworks/avatar': 'packages/avatar',
+  '@oneworks/avatar-react': 'packages/react',
+  '@oneworks/avatar-web': 'packages/web',
+  '@oneworks/avatar-vue': 'packages/vue'
+}
+const name = args[args.indexOf('--filter') + 1]
+const destination = args[args.indexOf('--pack-destination') + 1]
+if (!names[name] || !destination) process.exit(2)
+const manifest = JSON.parse(readFileSync(join(process.cwd(), names[name], 'package.json')))
+delete manifest.dependencies
+const staging = mkdtempSync(join(tmpdir(), 'avatar-fake-pack-'))
+const packageDirectory = join(staging, 'package')
+require('node:fs').mkdirSync(packageDirectory)
+writeFileSync(join(packageDirectory, 'package.json'), JSON.stringify(manifest))
+const tarball = name.slice(1).replace('/', '-') + '-' + manifest.version + '.tgz'
+execFileSync('tar', ['-czf', join(destination, tarball), 'package'], { cwd: staging })
+`)
+  writeFileSync(join(directory, 'npm'), '#!/bin/sh\nexit 1\n')
+  chmodSync(join(directory, 'pnpm'), 0o755)
+  chmodSync(join(directory, 'npm'), 0o755)
+  return directory
+}
+
+const run = (directory: string, args: string[]) => spawnSync(process.execPath, [script, ...args], {
+  cwd: root,
+  encoding: 'utf8',
+  env: {
+    ...process.env,
+    GITHUB_SHA: sourceSha,
+    NPM_PUBLISH_TARBALL_DIRECTORY: directory,
+    PATH: `${createFakePackageTools()}:${process.env.PATH}`
+  }
+})
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { force: true, recursive: true })
+})
+
+describe('immutable npm publish artifacts', () => {
+  it('prepares then verifies a real tarball fixture without modifying it', () => {
+    const artifactDirectory = temporaryDirectory()
+    expect(run(artifactDirectory, ['--prepare-only']).status).toBe(0)
+    const before = fingerprint(artifactDirectory)
+    expect(run(artifactDirectory, ['--verify-prepared']).status).toBe(0)
+    expect(fingerprint(artifactDirectory)).toEqual(before)
+  })
+
+  it('fails verification after a tarball is tampered without touching the candidate files', () => {
+    const artifactDirectory = temporaryDirectory()
+    expect(run(artifactDirectory, ['--prepare-only']).status).toBe(0)
+    const tarball = join(artifactDirectory, `oneworks-avatar-${version}.tgz`)
+    writeFileSync(tarball, 'tampered')
+    const before = fingerprint(artifactDirectory)
+    expect(run(artifactDirectory, ['--verify-prepared']).status).not.toBe(0)
+    expect(fingerprint(artifactDirectory)).toEqual(before)
+  })
+
+  it('fails verification when the artifact directory contains an extra tarball', () => {
+    const artifactDirectory = temporaryDirectory()
+    expect(run(artifactDirectory, ['--prepare-only']).status).toBe(0)
+    writeFileSync(join(artifactDirectory, 'unexpected.tgz'), 'extra')
+    expect(run(artifactDirectory, ['--verify-prepared']).status).not.toBe(0)
+  })
+
+  it('fails verification when a required tarball is missing', () => {
+    const artifactDirectory = temporaryDirectory()
+    expect(run(artifactDirectory, ['--prepare-only']).status).toBe(0)
+    unlinkSync(join(artifactDirectory, `oneworks-avatar-vue-${version}.tgz`))
+    expect(run(artifactDirectory, ['--verify-prepared']).status).not.toBe(0)
+  })
+
+  it('fails verification when the manifest attempts a tarball path traversal', () => {
+    const artifactDirectory = temporaryDirectory()
+    expect(run(artifactDirectory, ['--prepare-only']).status).toBe(0)
+    const manifestPath = join(artifactDirectory, 'avatar-sdk-candidate.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    manifest.packages[0].tarball = '../outside.tgz'
+    writeFileSync(manifestPath, JSON.stringify(manifest))
+    expect(run(artifactDirectory, ['--verify-prepared']).status).not.toBe(0)
+  })
+
+  it.each([
+    ['--prepare-only', '--publish-prepared'],
+    ['--prepare-only', '--verify-prepared'],
+    ['--publish-prepared', '--verify-prepared']
+  ])('rejects mutually exclusive modes: %s %s', (first, second) => {
+    const result = run(temporaryDirectory(), [first, second])
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('mutually exclusive')
+  })
+})

--- a/scripts/publish-sdk-packages.mjs
+++ b/scripts/publish-sdk-packages.mjs
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { spawnSync } from 'node:child_process'
-import { mkdir, mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -10,6 +10,8 @@ import { verifyAvatarSdkAttestations } from './avatar-sdk-provenance.mjs'
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const prepareOnly = process.argv.includes('--prepare-only')
 const publishPrepared = process.argv.includes('--publish-prepared')
+const verifyPrepared = process.argv.includes('--verify-prepared')
+const shouldPack = !publishPrepared && !verifyPrepared
 const dryRun = process.argv.includes('--dry-run') || prepareOnly
 const publishTag = process.env.PUBLISH_TAG?.trim() || 'rc'
 const packages = [
@@ -22,11 +24,11 @@ const packages = [
 if (!/^[a-z0-9][a-z0-9._-]*$/u.test(publishTag)) {
   throw new Error(`Invalid npm publish tag: ${publishTag}`)
 }
-if (prepareOnly && publishPrepared) {
-  throw new Error('--prepare-only and --publish-prepared are mutually exclusive')
+if ([prepareOnly, publishPrepared, verifyPrepared].filter(Boolean).length > 1) {
+  throw new Error('--prepare-only, --publish-prepared, and --verify-prepared are mutually exclusive')
 }
-if (publishPrepared && process.env.NPM_PUBLISH_TARBALL_DIRECTORY == null) {
-  throw new Error('--publish-prepared requires NPM_PUBLISH_TARBALL_DIRECTORY')
+if ((publishPrepared || verifyPrepared) && process.env.NPM_PUBLISH_TARBALL_DIRECTORY == null) {
+  throw new Error('--publish-prepared and --verify-prepared require NPM_PUBLISH_TARBALL_DIRECTORY')
 }
 
 const run = (command, args, options = {}) => {
@@ -47,6 +49,49 @@ const run = (command, args, options = {}) => {
 const readJson = async file => JSON.parse(await readFile(file, 'utf8'))
 const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))
 const sha512Integrity = bytes => `sha512-${createHash('sha512').update(bytes).digest('base64')}`
+
+const expectedTarballName = ({ name }, version) => `${name.slice(1).replace('/', '-')}-${version}.tgz`
+
+const exactNames = (actual, expected, description) => {
+  if (actual.length !== expected.length || actual.some((name, index) => name !== expected[index])) {
+    throw new Error(`${description} must contain exactly: ${expected.join(', ')}`)
+  }
+}
+
+const verifyArtifactDirectory = async ({ allowManifest, tarballDirectory, tarballNames }) => {
+  const entries = await readdir(tarballDirectory, { withFileTypes: true })
+  const expected = [...tarballNames, ...(allowManifest ? ['avatar-sdk-candidate.json'] : [])].sort()
+  exactNames(entries.map(entry => entry.name).sort(), expected, 'Prepared npm tarball directory')
+  for (const entry of entries) {
+    if (!entry.isFile()) throw new Error(`Prepared npm tarball entry is not a regular file: ${entry.name}`)
+  }
+}
+
+const verifyArtifactManifest = ({ manifest, releasePackages, sourceSha, version }) => {
+  if (
+    manifest?.schema !== 1 || !/^[0-9a-f]{40}$/u.test(sourceSha) ||
+    manifest?.sourceSha !== sourceSha || manifest?.version !== version
+  ) {
+    throw new Error('Prepared npm tarball manifest does not match the exact source or version')
+  }
+  if (!Array.isArray(manifest.packages) || manifest.packages.length !== releasePackages.length) {
+    throw new Error('Prepared npm tarball manifest does not list exactly four packages')
+  }
+  const expected = new Map(releasePackages.map(releasePackage => [releasePackage.name, releasePackage]))
+  const seen = new Set()
+  for (const item of manifest.packages) {
+    const releasePackage = expected.get(item?.name)
+    if (
+      releasePackage == null || seen.has(item.name) ||
+      item.tarball !== path.basename(releasePackage.tarballPath) ||
+      item.integrity !== releasePackage.integrity
+    ) {
+      throw new Error('Prepared npm tarball manifest package identity or integrity does not match')
+    }
+    seen.add(item.name)
+  }
+  if (seen.size !== expected.size) throw new Error('Prepared npm tarball manifest is missing a package')
+}
 
 const npmView = (selector, field) => {
   const result = run('npm', ['view', selector, field, '--json'], { allowFailure: true })
@@ -101,7 +146,7 @@ const verifyRegistryPackage = async ({ integrity, name, version }) => {
   throw new Error(`${selector} did not converge in the npm registry with tag ${publishTag}`)
 }
 
-const temporaryRoot = publishPrepared
+const temporaryRoot = (publishPrepared || verifyPrepared)
   ? undefined
   : await mkdtemp(path.join(tmpdir(), 'oneworks-avatar-publish-'))
 const tarballDirectory = process.env.NPM_PUBLISH_TARBALL_DIRECTORY == null
@@ -109,7 +154,7 @@ const tarballDirectory = process.env.NPM_PUBLISH_TARBALL_DIRECTORY == null
   : path.resolve(process.env.NPM_PUBLISH_TARBALL_DIRECTORY)
 
 try {
-  if (!publishPrepared) await mkdir(tarballDirectory, { recursive: true })
+  if (shouldPack) await mkdir(tarballDirectory, { recursive: true })
 
   const manifests = await Promise.all(
     packages.map(async packageInfo => ({
@@ -136,20 +181,22 @@ try {
     }
   }
 
-  if (!publishPrepared) {
+  if (shouldPack) {
     run('pnpm', ['build:sdk'])
     for (const { name } of packages) {
       run('pnpm', ['--filter', name, 'pack', '--pack-destination', tarballDirectory])
     }
   }
 
-  const tarballNames = await readdir(tarballDirectory)
+  const tarballNames = packages.map(packageInfo => expectedTarballName(packageInfo, version)).sort()
+  await verifyArtifactDirectory({
+    allowManifest: publishPrepared || verifyPrepared,
+    tarballDirectory,
+    tarballNames
+  })
   const releasePackages = []
   for (const { directory, name } of packages) {
-    const tarballName = `${name.slice(1).replace('/', '-')}-${version}.tgz`
-    if (!tarballNames.includes(tarballName)) {
-      throw new Error(`Missing exact packed tarball ${tarballName} for ${name}`)
-    }
+    const tarballName = expectedTarballName({ name }, version)
     const tarballPath = path.join(tarballDirectory, tarballName)
     const packedManifest = JSON.parse(run('tar', ['-xOf', tarballPath, 'package/package.json']).stdout)
     if (
@@ -169,8 +216,42 @@ try {
     releasePackages.push({ integrity, name, tarballPath, version })
   }
 
-  const publicationPlan = []
-  const preflightFailures = []
+  const artifactManifest = {
+    schema: 1,
+    sourceSha: process.env.GITHUB_SHA?.trim() ?? '',
+    version,
+    packages: releasePackages.map(({ integrity, name, tarballPath }) => ({
+      integrity,
+      name,
+      tarball: path.basename(tarballPath)
+    }))
+  }
+  if (prepareOnly) {
+    if (!/^[0-9a-f]{40}$/u.test(artifactManifest.sourceSha)) {
+      throw new Error('Prepared npm tarballs require an exact GITHUB_SHA')
+    }
+    await writeFile(
+      path.join(tarballDirectory, 'avatar-sdk-candidate.json'),
+      `${JSON.stringify(artifactManifest, null, 2)}\n`
+    )
+  }
+  if (publishPrepared || verifyPrepared) {
+    const manifestPath = path.join(tarballDirectory, 'avatar-sdk-candidate.json')
+    const preparedManifest = await readJson(manifestPath)
+    verifyArtifactManifest({
+      manifest: preparedManifest,
+      releasePackages,
+      sourceSha: artifactManifest.sourceSha,
+      version
+    })
+  }
+  if (verifyPrepared) {
+    process.stdout.write(`Verified immutable OneWorks Avatar SDK tarballs for ${version}.\n`)
+  }
+
+  if (!verifyPrepared) {
+    const publicationPlan = []
+    const preflightFailures = []
   for (const releasePackage of releasePackages) {
     const selector = `${releasePackage.name}@${version}`
     const registryIntegrity = npmView(selector, 'dist.integrity')
@@ -249,9 +330,10 @@ try {
     process.stdout.write(`Published and verified OneWorks Avatar SDK ${version}.\n`)
   }
 
-  if (process.env.GITHUB_OUTPUT != null) {
-    const fs = await import('node:fs/promises')
-    await fs.appendFile(process.env.GITHUB_OUTPUT, `version=${version}\n`)
+    if (process.env.GITHUB_OUTPUT != null) {
+      const fs = await import('node:fs/promises')
+      await fs.appendFile(process.env.GITHUB_OUTPUT, `version=${version}\n`)
+    }
   }
 } finally {
   if (temporaryRoot != null) await rm(temporaryRoot, { force: true, recursive: true })

--- a/scripts/verify-npm-publish-candidate.mjs
+++ b/scripts/verify-npm-publish-candidate.mjs
@@ -1,0 +1,55 @@
+const EXPECTED_REPOSITORY = 'oneworks-ai/avatar'
+const EXPECTED_WORKFLOW_PATH = '.github/workflows/npm-publish.yml'
+const EXPECTED_VALIDATE_JOB = 'test-pack-validate'
+
+const fail = message => {
+  throw new Error(`Unsafe npm publish candidate: ${message}`)
+}
+
+export const verifyNpmPublishCandidate = ({ artifacts, jobs, run, sourceSha, version, workflow }) => {
+  if (!/^[0-9a-f]{40}$/u.test(sourceSha)) fail('source SHA is not exact')
+  if (run?.repository?.full_name !== EXPECTED_REPOSITORY) fail('repository does not match')
+  if (run?.head_sha !== sourceSha) fail('source SHA does not match')
+  if (run?.status !== 'completed' || !['success', 'failure'].includes(run?.conclusion)) {
+    fail('workflow run did not reach a reusable terminal state')
+  }
+  if (run?.event !== 'workflow_dispatch' || run?.head_branch !== 'main') {
+    fail('workflow run was not dispatched from protected main')
+  }
+  if (workflow?.path !== EXPECTED_WORKFLOW_PATH || run?.workflow_id !== workflow?.id) {
+    fail('workflow identity does not match')
+  }
+  if (!Array.isArray(jobs) || !jobs.some(job =>
+    job?.name === EXPECTED_VALIDATE_JOB && job?.status === 'completed' && job?.conclusion === 'success'
+  )) fail('validate job did not succeed')
+
+  const expectedName = `avatar-sdk-${version}`
+  const matchingArtifacts = Array.isArray(artifacts)
+    ? artifacts.filter(artifact => artifact?.name === expectedName)
+    : []
+  if (matchingArtifacts.length !== 1) fail('artifact name and version are not unique')
+  const [artifact] = matchingArtifacts
+  if (artifact?.expired !== false || artifact?.workflow_run?.id !== run?.id) {
+    fail('artifact is expired or does not belong to the candidate run')
+  }
+  return artifact
+}
+
+const readJson = async path => JSON.parse(await (await import('node:fs/promises')).readFile(path, 'utf8'))
+
+if (process.argv[1] != null && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const [runPath, jobsPath, artifactsPath, workflowPath] = process.argv.slice(2)
+  const sourceSha = process.env.SOURCE_SHA?.trim() ?? ''
+  const version = process.env.VERSION?.trim() ?? ''
+  if ([runPath, jobsPath, artifactsPath, workflowPath].some(value => value == null) || version.length === 0) {
+    fail('missing GitHub API evidence or release version')
+  }
+  verifyNpmPublishCandidate({
+    artifacts: (await readJson(artifactsPath)).artifacts,
+    jobs: (await readJson(jobsPath)).jobs,
+    run: await readJson(runPath),
+    sourceSha,
+    version,
+    workflow: await readJson(workflowPath)
+  })
+}


### PR DESCRIPTION
## Summary

Recover npm publishing by reusing an exact, previously validated SDK artifact set. This PR does not publish `rc.8`; the artifact test fixture is adapted to the recomposed live-main package version.

## Preflight and evidence

- GitHub identity/API and SSH preflight confirmed account `NWYLZW` and repository `oneworks-ai/avatar`.
- Re-composed exact base/live main: `473341758fc479f5e963135cdb9bd08b9d2f3d10`.
- Frozen five-path combined path+SHA-256 digest: `62a25cb98940ab132eb13dd96c659685ce8aca53d1e0f9ad698d9494f4bd5f37`.
- `candidate_run_id` is an optional workflow-dispatch input; when supplied, preflight verifies the exact successful validation run, source SHA, workflow identity, job, artifact ownership, and expiration.
- Candidate tarballs are immutable and verified before publish; validation is fail-closed for source, package, manifest, integrity, and artifact-directory drift.
- SDK artifact retention is 7 days.

## Verification

- `pnpm exec vitest run __tests__/publishSdkPackagesArtifact.spec.ts __tests__/npmPublishCandidate.spec.ts __tests__/avatarSdkProvenance.spec.ts`
- 39 tests passed
- Node `--check` passed for both publish scripts
- Ruby YAML parse passed
- `git diff --check` passed

Publishing remains restricted to protected `main` and keeps OIDC/token authentication checks and post-publish verification.