### PR TITLE
ci: harden Avatar SDK PR evidence gate

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -10,7 +10,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  pull-requests: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -20,8 +22,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  sdk:
-    name: build-test-pack
+  validate:
+    name: validate-sdk-ci
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -30,6 +32,40 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Guard reusable evidence trust boundary
+        id: evidence-eligibility
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.before || '' }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          allowed=false
+          if [[ "$EVENT_NAME" == push &&
+                "$BASE_SHA" =~ ^[[:xdigit:]]{40}$ &&
+                "$HEAD_SHA" =~ ^[[:xdigit:]]{40}$ ]] &&
+             git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null &&
+             git cat-file -e "$HEAD_SHA^{commit}" 2>/dev/null; then
+            mapfile -d '' -t trust_changes < <(git diff --name-only --no-renames -z "$BASE_SHA" "$HEAD_SHA" -- \
+              .github/workflows/sdk-ci.yml scripts/verify-pr-ci-evidence.mjs)
+            if (( ${#trust_changes[@]} == 0 )); then
+              allowed=true
+            fi
+          fi
+
+          printf 'allowed=%s\n' "$allowed" >> "$GITHUB_OUTPUT"
+          printf 'Reusable evidence lookup allowed: %s\n' "$allowed"
+
+      - name: Collect trusted pull-request CI evidence
+        id: evidence
+        if: steps.evidence-eligibility.outputs.allowed == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/verify-pr-ci-evidence.mjs
 
       - name: Classify validation scope
         id: scope
@@ -42,48 +78,83 @@ jobs:
           set -euo pipefail
 
           scope=full
-          if [[ "$EVENT_NAME" != workflow_dispatch ]] &&
-             [[ "$BASE_SHA" =~ ^[[:xdigit:]]{40}$ ]] &&
+          evidence_scope='${{ steps.evidence.outputs.scope }}'
+          if [[ "$EVENT_NAME" != workflow_dispatch &&
+                "$BASE_SHA" =~ ^[[:xdigit:]]{40}$ ]] &&
              [[ "$HEAD_SHA" =~ ^[[:xdigit:]]{40}$ ]] &&
              git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null &&
              git cat-file -e "$HEAD_SHA^{commit}" 2>/dev/null; then
             mapfile -d '' -t changes < <(git diff --name-status --no-renames -z "$BASE_SHA" "$HEAD_SHA")
             if (( ${#changes[@]} > 0 && ${#changes[@]} % 2 == 0 )); then
-              scope=documentation
-              documentation_pattern='^(README(\.[[:alnum:]_-]+)?\.md|AGENTS\.md|packages/[[:alnum:]_.-]+/(README(\.[[:alnum:]_-]+)?|AGENTS)\.md|\.github/assets/[[:alnum:]_.-]+\.(png|jpe?g|gif|webp)|docs(/[[:alnum:]_.-]+)+\.(md|png|jpe?g|gif|webp|svg)|skills/[a-z0-9]+(-[a-z0-9]+)*/(SKILL\.md|references/[[:alnum:]_.-]+\.md|agents/openai\.yaml))$'
+              path_class=must-full
+              has_docs_assets=false
+              has_reusable_source=false
+              cover_pattern='^\.github/assets/avatar-cover-(light|dark)-(en|zh-Hans)\.jpg$'
+              documentation_pattern='^(README(\.[[:alnum:]_-]+)?\.md|AGENTS\.md|packages/[[:alnum:]_.-]+/(README(\.[[:alnum:]_-]+)?|AGENTS)\.md|docs(/[[:alnum:]_.-]+)+\.(md|png|jpe?g|gif|webp|svg)|skills/[a-z0-9]+(-[a-z0-9]+)*/(SKILL\.md|references/[[:alnum:]_.-]+\.md|agents/openai\.yaml))$'
+              reusable_source_pattern='^(src/|packages/|scripts/[[:alnum:]_.-]+\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig[^/]*\.json$|vite\.config\.[[:alnum:]_-]+$)'
+              must_full_pattern='^(scripts/readme-cover\.html|\.github/assets/bear-breed-profiles\.png|\.github/)'
 
               for (( index = 0; index < ${#changes[@]}; index += 2 )); do
                 change_status=${changes[index]}
                 changed_path=${changes[index + 1]}
 
-                if [[ ! "$change_status" =~ ^[AM]$ ]] ||
-                   [[ ! "$changed_path" =~ $documentation_pattern ]]; then
-                  scope=full
+                if [[ ! "$change_status" =~ ^[AM]$ ]]; then
                   break
                 fi
 
                 head_entry=$(git ls-tree "$HEAD_SHA" -- "$changed_path")
                 if [[ ! "$head_entry" =~ ^100644[[:space:]]blob[[:space:]][[:xdigit:]]{40}[[:space:]] ]]; then
-                  scope=full
                   break
                 fi
 
                 if [[ "$change_status" == M ]]; then
                   base_entry=$(git ls-tree "$BASE_SHA" -- "$changed_path")
                   if [[ ! "$base_entry" =~ ^100644[[:space:]]blob[[:space:]][[:xdigit:]]{40}[[:space:]] ]]; then
-                    scope=full
                     break
                   fi
                 fi
+
+                # The four generated README covers are the only .github paths
+                # eligible for docs-assets. Check them before the broad
+                # .github must-full rule so precedence cannot shadow them.
+                if [[ "$changed_path" =~ $cover_pattern ]]; then
+                  has_docs_assets=true
+                elif [[ "$changed_path" =~ $must_full_pattern ]]; then
+                  break
+                elif [[ "$changed_path" =~ $documentation_pattern ]]; then
+                  has_docs_assets=true
+                elif [[ "$changed_path" =~ $reusable_source_pattern ]]; then
+                  has_reusable_source=true
+                else
+                  break
+                fi
               done
+
+              if [[ "$index" -eq "${#changes[@]}" ]]; then
+                if [[ "$has_docs_assets" == true && "$has_reusable_source" == false ]]; then
+                  path_class=docs-assets
+                elif [[ "$has_docs_assets" == false && "$has_reusable_source" == true ]]; then
+                  path_class=reusable-source
+                fi
+              fi
+
+              if [[ "$EVENT_NAME" == pull_request && "$path_class" == docs-assets ]]; then
+                scope=docs-assets
+              elif [[ "$EVENT_NAME" == push && "$evidence_scope" == reused-pr-ci ]]; then
+                if [[ "$path_class" == docs-assets ]]; then
+                  scope=docs-assets
+                elif [[ "$path_class" == reusable-source ]]; then
+                  scope=reused-pr-ci
+                fi
+              fi
             fi
           fi
 
           printf 'scope=%s\nbase=%s\nhead=%s\n' "$scope" "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
           printf 'Validation scope: %s\n' "$scope"
 
-      - name: Validate documentation and skill metadata
-        if: steps.scope.outputs.scope == 'documentation'
+      - name: Validate documentation, cover assets, and skill metadata
+        if: steps.scope.outputs.scope == 'docs-assets'
         shell: bash
         env:
           BASE_SHA: ${{ steps.scope.outputs.base }}
@@ -118,6 +189,30 @@ jobs:
               for path in changed
               if pathlib.Path(path).suffix.lower() in {".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"}
           }
+          cover_images = {
+              ".github/assets/avatar-cover-light-en.jpg",
+              ".github/assets/avatar-cover-dark-en.jpg",
+              ".github/assets/avatar-cover-light-zh-Hans.jpg",
+              ".github/assets/avatar-cover-dark-zh-Hans.jpg",
+          }
+          required_readme_covers = {}
+          if any(path in cover_images for path in changed):
+              markdown_files.update({root / "README.md", root / "README.zh-Hans.md"})
+              for image in cover_images:
+                  media_files.add(root / image)
+              required_readme_covers = {
+                  root / "README.md": {
+                      ".github/assets/avatar-cover-dark-en.jpg",
+                      ".github/assets/avatar-cover-light-en.jpg",
+                  },
+                  root / "README.zh-Hans.md": {
+                      ".github/assets/avatar-cover-dark-zh-Hans.jpg",
+                      ".github/assets/avatar-cover-light-zh-Hans.jpg",
+                  },
+              }
+              for readme in required_readme_covers:
+                  if readme.is_symlink() or not readme.is_file():
+                      raise SystemExit(f"Missing regular README cover owner: {readme.relative_to(root)}")
 
           ruby_yaml_parser = r"""
           require "json"
@@ -254,6 +349,14 @@ jobs:
               targets.extend(re.findall(r"\b(?:href|src)\s*=\s*[\"']([^\"']+)[\"']", markdown, re.I))
               for source_set in re.findall(r"\bsrcset\s*=\s*[\"']([^\"']+)[\"']", markdown, re.I):
                   targets.extend(candidate.strip().split()[0] for candidate in source_set.split(",") if candidate.strip())
+              expected_covers = required_readme_covers.get(markdown_file)
+              if expected_covers is not None:
+                  missing_covers = expected_covers.difference(targets)
+                  if missing_covers:
+                      raise SystemExit(
+                          f"README must link required cover(s): {markdown_file.relative_to(root)} -> "
+                          f"{', '.join(sorted(missing_covers))}"
+                      )
               for target in targets:
                   if target.startswith("#"):
                       continue
@@ -290,7 +393,7 @@ jobs:
           PY
 
       - name: Checkout shared OneWorks sources
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         uses: actions/checkout@v4
         with:
           repository: oneworks-ai/app
@@ -298,13 +401,13 @@ jobs:
           submodules: false
 
       - name: Setup pnpm
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         uses: pnpm/action-setup@v4
         with:
           version: 11.7.0
 
       - name: Setup Node.js
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         uses: actions/setup-node@v4
         with:
           node-version-file: app-source/.node-version
@@ -315,29 +418,163 @@ jobs:
             app-source/pnpm-lock.yaml
 
       - name: Install dependencies
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         run: pnpm install --frozen-lockfile
 
       - name: Test editor and runtime contracts
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         run: pnpm test
 
       - name: Typecheck app source
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         run: pnpm typecheck
 
       - name: Build and typecheck SDK packages
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         run: pnpm typecheck:sdk
 
       - name: Build app source
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         run: pnpm build:app-source
 
       - name: Test packed packages in a clean consumer
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         run: pnpm smoke:sdk
 
       - name: Audit production dependencies
-        if: steps.scope.outputs.scope != 'documentation'
+        if: steps.scope.outputs.scope == 'full'
         run: pnpm audit --prod --audit-level high
+
+      - name: Validate reused PR CI source diff
+        if: steps.scope.outputs.scope == 'reused-pr-ci'
+        shell: bash
+        env:
+          BASE_SHA: ${{ steps.scope.outputs.base }}
+          HEAD_SHA: ${{ steps.scope.outputs.head }}
+        run: git diff --check "$BASE_SHA" "$HEAD_SHA"
+
+  sdk:
+    name: build-test-pack
+    needs: validate
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Enforce validation success
+        shell: bash
+        env:
+          VALIDATION_RESULT: ${{ needs.validate.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$VALIDATION_RESULT" != success ]]; then
+            printf 'Validation job did not succeed: %s\n' "$VALIDATION_RESULT" >&2
+            exit 1
+          fi
+
+      - name: Produce isolated pull-request CI evidence
+        id: evidence
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY_ID: ${{ github.repository_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REPOSITORY_ID: ${{ github.event.pull_request.base.repo.id }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+          import { join } from 'node:path'
+
+          const shaPattern = /^[0-9a-f]{40}$/u
+          const integer = value => /^\d+$/u.test(value) ? Number(value) : Number.NaN
+          const required = name => {
+            const value = process.env[name]
+            if (!value) throw new Error(`Missing trusted context: ${name}`)
+            return value
+          }
+          const request = async path => {
+            const controller = new AbortController()
+            const timer = setTimeout(() => controller.abort(), 10_000)
+            try {
+              const response = await fetch(`${required('GITHUB_API_URL')}/repos/${required('GITHUB_REPOSITORY')}${path}`, {
+                signal: controller.signal,
+                headers: {
+                  accept: 'application/vnd.github+json',
+                  authorization: `Bearer ${required('GITHUB_TOKEN')}`,
+                  'x-github-api-version': '2022-11-28'
+                }
+              })
+              if (!response.ok) throw new Error(`GitHub API returned ${response.status}`)
+              return response.json()
+            } finally {
+              clearTimeout(timer)
+            }
+          }
+
+          const repositoryId = integer(required('REPOSITORY_ID'))
+          const runId = integer(required('GITHUB_RUN_ID'))
+          const runAttempt = integer(required('GITHUB_RUN_ATTEMPT'))
+          const pullRequestNumber = integer(required('PR_NUMBER'))
+          const baseRepositoryId = integer(required('BASE_REPOSITORY_ID'))
+          const headRepositoryId = integer(required('HEAD_REPOSITORY_ID'))
+          const integrationSha = required('GITHUB_SHA')
+          const baseSha = required('BASE_SHA')
+          const headSha = required('HEAD_SHA')
+          if (![repositoryId, runId, runAttempt, pullRequestNumber, baseRepositoryId, headRepositoryId].every(Number.isInteger) ||
+              ![integrationSha, baseSha, headSha].every(value => shaPattern.test(value))) {
+            throw new Error('Invalid trusted evidence identity')
+          }
+
+          const [run, integration] = await Promise.all([
+            request(`/actions/runs/${runId}`),
+            request(`/commits/${integrationSha}`)
+          ])
+          if (run.id !== runId || run.run_attempt !== runAttempt || run.workflow_id == null ||
+              run.name !== 'Avatar SDK CI' || run.path !== '.github/workflows/sdk-ci.yml' ||
+              run.event !== 'pull_request' || run.head_sha !== headSha ||
+              run.repository?.id !== repositoryId || integration.sha !== integrationSha ||
+              integration.commit?.tree?.sha == null || integration.parents?.length !== 2 ||
+              integration.parents[0]?.sha !== baseSha || integration.parents[1]?.sha !== headSha) {
+            throw new Error('Official PR run or integration commit identity mismatch')
+          }
+
+          const evidence = {
+            schema_version: 1,
+            generated_at: new Date().toISOString(),
+            repository: { id: repositoryId, full_name: required('GITHUB_REPOSITORY') },
+            workflow: { id: run.workflow_id, name: run.name, path: run.path },
+            run: { id: runId, attempt: runAttempt, event: run.event, head_sha: run.head_sha },
+            pull_request: {
+              number: pullRequestNumber,
+              base: { sha: baseSha, repository: { id: baseRepositoryId, full_name: required('BASE_REPOSITORY') } },
+              head: { sha: headSha, repository: { id: headRepositoryId, full_name: required('HEAD_REPOSITORY') } }
+            },
+            integration: {
+              sha: integrationSha,
+              tree: integration.commit.tree.sha,
+              parents: integration.parents.map(parent => parent.sha)
+            }
+          }
+          const directory = mkdtempSync(join(required('RUNNER_TEMP'), 'avatar-pr-ci-evidence-'))
+          mkdirSync(directory, { recursive: true, mode: 0o700 })
+          const evidencePath = join(directory, 'pr-ci-evidence.json')
+          writeFileSync(evidencePath, `${JSON.stringify(evidence)}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+          writeFileSync(required('GITHUB_OUTPUT'), `path=${evidencePath}\n`, { encoding: 'utf8', flag: 'a' })
+          console.log('Created isolated PR CI evidence for the current run attempt.')
+          NODE
+
+      - name: Upload pull-request CI evidence
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: avatar-pr-ci-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.evidence.outputs.path }}
+          if-no-files-found: error
+          retention-days: 2

--- a/__tests__/prCiEvidence.spec.ts
+++ b/__tests__/prCiEvidence.spec.ts
@@ -1,0 +1,254 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { collectPages, createApi, downloadEvidence, output, validateEvidence, verify } from '../scripts/verify-pr-ci-evidence.mjs'
+
+const main = 'a'.repeat(40)
+const head = 'b'.repeat(40)
+const integration = 'c'.repeat(40)
+const base = 'd'.repeat(40)
+const tree = 'e'.repeat(40)
+const repository = { id: 7, full_name: 'oneworks-ai/avatar' }
+const now = Date.parse('2026-08-31T00:10:00Z')
+const pullRequest = {
+  number: 42,
+  merged_at: '2026-08-31T00:05:00Z',
+  merge_commit_sha: main,
+  base: { ref: 'main', sha: 'f'.repeat(40), repo: repository },
+  head: { sha: head, repo: repository }
+}
+const workflow = { id: 17, name: 'Avatar SDK CI', path: '.github/workflows/sdk-ci.yml' }
+const run = {
+  id: 99,
+  run_attempt: 1,
+  workflow_id: 17,
+  name: 'Avatar SDK CI',
+  path: '.github/workflows/sdk-ci.yml',
+  event: 'pull_request',
+  status: 'completed',
+  conclusion: 'success',
+  head_sha: head,
+  repository,
+  head_repository: repository,
+  pull_requests: []
+}
+// The attempt-scoped jobs endpoint binds the attempt in its URL; live job
+// payloads may omit run_attempt entirely.
+const job = { id: 500, name: 'build-test-pack', status: 'completed', conclusion: 'success' }
+const artifact = {
+  id: 700,
+  name: 'avatar-pr-ci-evidence-99-1',
+  expired: false,
+  created_at: '2026-08-31T00:06:00Z',
+  expires_at: '2026-09-02T00:06:00Z',
+  workflow_run: { id: 99, repository_id: 7, head_repository_id: 7, head_sha: head }
+}
+const mainCommit = { sha: main, commit: { tree: { sha: tree } }, parents: [{ sha: base }] }
+const integrationCommit = { sha: integration, commit: { tree: { sha: tree } }, parents: [{ sha: base }, { sha: head }] }
+const evidence = {
+  schema_version: 1,
+  generated_at: '2026-08-31T00:05:30Z',
+  repository,
+  workflow,
+  run: { id: 99, attempt: 1, event: 'pull_request', head_sha: head },
+  pull_request: {
+    number: 42,
+    base: { sha: base, repository },
+    head: { sha: head, repository }
+  },
+  integration: { sha: integration, tree, parents: [base, head] }
+}
+const env = {
+  GITHUB_EVENT_NAME: 'push',
+  GITHUB_REF: 'refs/heads/main',
+  GITHUB_SHA: main,
+  GITHUB_REPOSITORY: repository.full_name,
+  GITHUB_REPOSITORY_ID: String(repository.id),
+  GITHUB_TOKEN: 'token',
+  GITHUB_API_URL: 'https://api.github.test'
+}
+
+type FixtureOverrides = {
+  associated?: unknown
+  workflows?: unknown[]
+  runs?: unknown[]
+  artifacts?: unknown[]
+  jobs?: unknown[]
+  mainCommit?: unknown
+  integrationCommit?: unknown
+  evidence?: unknown
+  throwOnEvidence?: Error
+}
+
+const fixture = (overrides: FixtureOverrides = {}) => {
+  const requested: string[] = []
+  const values = {
+    associated: overrides.associated ?? [pullRequest],
+    workflows: overrides.workflows ?? [workflow],
+    runs: overrides.runs ?? [run],
+    artifacts: overrides.artifacts ?? [artifact],
+    jobs: overrides.jobs ?? [job],
+    mainCommit: overrides.mainCommit ?? mainCommit,
+    integrationCommit: overrides.integrationCommit ?? integrationCommit
+  }
+  const requestJson = async (url: string) => {
+    requested.push(url)
+    if (url.includes(`/commits/${main}/pulls`)) return values.associated
+    if (url.includes('/actions/workflows?')) return { total_count: values.workflows.length, workflows: values.workflows }
+    if (url.endsWith(`/commits/${main}`)) return values.mainCommit
+    if (url.includes('/actions/workflows/17/runs?')) return { total_count: values.runs.length, workflow_runs: values.runs }
+    if (url.includes('/actions/runs/99/artifacts?')) return { total_count: values.artifacts.length, artifacts: values.artifacts }
+    if (url.includes('/actions/runs/99/attempts/1/jobs?')) return { total_count: values.jobs.length, jobs: values.jobs }
+    if (url.endsWith(`/commits/${integration}`)) return values.integrationCommit
+    throw new Error(`Unexpected fixture request: ${url}`)
+  }
+  const readEvidence = async () => {
+    if (overrides.throwOnEvidence) throw overrides.throwOnEvidence
+    return overrides.evidence ?? evidence
+  }
+  return { requestJson, readEvidence, requested }
+}
+
+const execute = async (overrides: FixtureOverrides = {}) => {
+  const testFixture = fixture(overrides)
+  const result = await verify({ env, requestJson: testFixture.requestJson, readEvidence: testFixture.readEvidence, now })
+  return { result, requested: testFixture.requested }
+}
+
+describe('post-merge PR CI evidence', () => {
+  it('reaches the exact path with official head_sha=head and merged pull_requests=[]', async () => {
+    const { result, requested } = await execute()
+    expect(result).toMatchObject({ reuse: true, reason: 'exact-pr-ci-evidence', run: { id: 99, attempt: 1 }, artifact: { id: 700 } })
+    expect(run.head_sha).toBe(head)
+    expect(run.pull_requests).toEqual([])
+    expect(requested.some(url => url.endsWith(`/commits/${integration}`))).toBe(true)
+    expect(requested.length).toBeLessThanOrEqual(8)
+  })
+
+  it.each([
+    ['old integration base', { evidence: { ...evidence, pull_request: { ...evidence.pull_request, base: { ...evidence.pull_request.base, sha: '1'.repeat(40) } } } }],
+    ['wrong integration parents', { evidence: { ...evidence, integration: { ...evidence.integration, parents: ['1'.repeat(40), head] } } }],
+    ['wrong integration tree', { evidence: { ...evidence, integration: { ...evidence.integration, tree: '1'.repeat(40) } } }],
+    ['wrong main tree', { mainCommit: { ...mainCommit, commit: { tree: { sha: '1'.repeat(40) } } } }],
+    ['wrong repository', { evidence: { ...evidence, repository: { id: 8, full_name: repository.full_name } } }],
+    ['wrong workflow', { evidence: { ...evidence, workflow: { ...workflow, id: 18 } } }],
+    ['wrong run', { evidence: { ...evidence, run: { ...evidence.run, id: 100 } } }],
+    ['wrong PR', { evidence: { ...evidence, pull_request: { ...evidence.pull_request, number: 43 } } }],
+    ['expired artifact', { artifacts: [{ ...artifact, expired: true }] }],
+    ['stale artifact', { artifacts: [{ ...artifact, created_at: '2026-08-01T00:00:00Z', expires_at: '2026-09-02T00:06:00Z' }] }],
+    ['wrong artifact repository', { artifacts: [{ ...artifact, workflow_run: { ...artifact.workflow_run, repository_id: 8 } }] }],
+    ['wrong artifact head', { artifacts: [{ ...artifact, workflow_run: { ...artifact.workflow_run, head_sha: '1'.repeat(40) } }] }],
+    ['failed required job', { jobs: [{ ...job, conclusion: 'failure' }] }],
+    ['wrong job attempt', { jobs: [{ ...job, run_attempt: 2 }] }]
+  ])('fails closed on %s', async (_label, overrides) => {
+    expect((await execute(overrides as FixtureOverrides)).result.reuse).toBe(false)
+  })
+
+  it('rejects missing and duplicate exact artifacts', async () => {
+    expect((await execute({ artifacts: [] })).result).toMatchObject({ reuse: false, reason: 'ambiguous-or-missing-evidence-artifact' })
+    expect((await execute({ artifacts: [artifact, { ...artifact, id: 701 }] })).result).toMatchObject({ reuse: false, reason: 'ambiguous-or-missing-evidence-artifact' })
+  })
+
+  it('rejects multiple successful runs but accepts a latest rerun attempt with older attempt artifacts present', async () => {
+    expect((await execute({ runs: [run, { ...run, id: 100 }] })).result).toMatchObject({ reuse: false, reason: 'ambiguous-or-missing-successful-run' })
+
+    const rerun = { ...run, run_attempt: 2 }
+    const rerunArtifact = {
+      ...artifact,
+      id: 702,
+      name: 'avatar-pr-ci-evidence-99-2'
+    }
+    const rerunEvidence = {
+      ...evidence,
+      run: { ...evidence.run, attempt: 2 }
+    }
+    const rerunFixture = fixture({ runs: [rerun], artifacts: [artifact, rerunArtifact], jobs: [{ ...job, run_attempt: 2 }], evidence: rerunEvidence })
+    const requestJson = async (url: string) => {
+      if (url.includes('/attempts/2/jobs?')) return { total_count: 1, jobs: [{ ...job, run_attempt: 2 }] }
+      return rerunFixture.requestJson(url)
+    }
+    await expect(verify({ env, requestJson, readEvidence: rerunFixture.readEvidence, now })).resolves.toMatchObject({ reuse: true, run: { attempt: 2 }, artifact: { id: 702 } })
+  })
+
+  it('filters old synchronize runs before ambiguity evaluation', async () => {
+    const oldSynchronize = { ...run, id: 98, head_sha: '1'.repeat(40) }
+    await expect(execute({ runs: [oldSynchronize, run] })).resolves.toMatchObject({ result: { reuse: true } })
+  })
+
+  it('fails closed for malformed JSON, zip/download failures, and API failures', async () => {
+    expect((await execute({ evidence: { malformed: true } })).result).toMatchObject({ reuse: false, reason: 'invalid-evidence-json' })
+    expect((await execute({ throwOnEvidence: new Error('invalid zip') })).result).toMatchObject({ reuse: false, reason: 'evidence-api-download-or-parse-failure' })
+    await expect(verify({ env, requestJson: async () => { throw new Error('denied') }, readEvidence: async () => evidence, now })).resolves.toMatchObject({ reuse: false, reason: 'evidence-api-download-or-parse-failure' })
+  })
+
+  it('downloads one bounded evidence JSON file without forwarding the token to artifact storage', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'avatar-evidence-zip-'))
+    writeFileSync(join(directory, 'pr-ci-evidence.json'), JSON.stringify(evidence))
+    execFileSync('zip', ['-q', 'evidence.zip', 'pr-ci-evidence.json'], { cwd: directory })
+    const archive = readFileSync(join(directory, 'evidence.zip'))
+    const calls: Array<{ url: string, authorization?: string }> = []
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input, options) => {
+      const url = String(input)
+      const headers = options?.headers as Record<string, string> | undefined
+      calls.push({ url, authorization: headers?.authorization })
+      if (url.includes('/actions/artifacts/700/zip')) {
+        return new Response(null, { status: 302, headers: { location: 'https://artifact-storage.test/signed' } })
+      }
+      return new Response(archive, { status: 200, headers: { 'content-length': String(archive.length) } })
+    }) as typeof fetch
+    try {
+      await expect(downloadEvidence({ artifact, apiUrl: env.GITHUB_API_URL, repository: env.GITHUB_REPOSITORY, token: env.GITHUB_TOKEN })).resolves.toEqual(evidence)
+      expect(calls).toEqual([
+        { url: 'https://api.github.test/repos/oneworks-ai/avatar/actions/artifacts/700/zip', authorization: 'Bearer token' },
+        { url: 'https://artifact-storage.test/signed', authorization: undefined }
+      ])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it.each([
+    ['workflow_runs', Array.from({ length: 100 }, (_, index) => ({ ...run, id: index + 1000, head_sha: '1'.repeat(40), conclusion: index % 2 ? 'failure' : 'cancelled' })), run],
+    ['artifacts', Array.from({ length: 100 }, (_, index) => ({ ...artifact, id: index + 1000, name: `noise-${index}` })), artifact]
+  ])('handles 100/101 pagination for %s', async (key, firstPage, finalItem) => {
+    const pages: number[] = []
+    const requestJson = async (url: string) => {
+      const page = Number(new URL(url).searchParams.get('page'))
+      pages.push(page)
+      return { total_count: 101, [key]: page === 1 ? firstPage : [finalItem] }
+    }
+    await expect(collectPages({ url: 'https://api.github.test/items?filter=exact', key, requestJson, token: 'token' })).resolves.toHaveLength(101)
+    expect(pages).toEqual([1, 2])
+  })
+
+  it('aborts timed-out API requests and writes a deterministic full output', async () => {
+    const request = createApi({ timeoutMs: 1 })
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (_url, options) => new Promise((_, reject) => options?.signal?.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })))) as typeof fetch
+    try {
+      await expect(request('https://example.invalid', 'token')).rejects.toMatchObject({ name: 'AbortError' })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    const target = join(mkdtempSync(join(tmpdir(), 'avatar-evidence-output-')), 'github-output')
+    output({ reuse: false, reason: 'fixture' }, target)
+    expect(readFileSync(target, 'utf8')).toBe('scope=full\nevidence_reason=fixture\n')
+  })
+
+  it('does not call the API for PR/manual events and treats a direct main push as full', async () => {
+    const requestJson = async () => { throw new Error('must not request') }
+    await expect(verify({ env: { ...env, GITHUB_EVENT_NAME: 'pull_request' }, requestJson })).resolves.toMatchObject({ reuse: false, reason: 'not-a-main-push' })
+    await expect(verify({ env: { ...env, GITHUB_EVENT_NAME: 'workflow_dispatch' }, requestJson })).resolves.toMatchObject({ reuse: false, reason: 'not-a-main-push' })
+    await expect(execute({ associated: [] })).resolves.toMatchObject({ result: { reuse: false, reason: 'ambiguous-or-no-associated-pr' } })
+  })
+
+  it('validates the pure evidence contract independently', () => {
+    expect(validateEvidence({ evidence, repository, workflow, run, pullRequest, artifact, mainCommit, integrationCommit, now })).toBe(true)
+  })
+})

--- a/__tests__/sdkCiWorkflow.spec.ts
+++ b/__tests__/sdkCiWorkflow.spec.ts
@@ -1,17 +1,193 @@
-import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
 const workflowPath = new URL('../.github/workflows/sdk-ci.yml', import.meta.url)
+const git = (cwd: string, args: string[]) => execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+const commit = (cwd: string, message: string) => {
+  git(cwd, ['add', '-A'])
+  git(cwd, ['-c', 'user.name=test', '-c', 'user.email=test@example.com', 'commit', '-m', message])
+  return git(cwd, ['rev-parse', 'HEAD'])
+}
+
+const workflowBlock = (name: string) => {
+  const workflow = readFileSync(workflowPath, 'utf8')
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')
+  const match = workflow.match(new RegExp(`      - name: ${escaped}\\n[\\s\\S]*?        run: \\|\\n([\\s\\S]*?)(?=\\n      - name:|\\n  sdk:)`, 'u'))
+  expect(match?.[1]).toBeTruthy()
+  return match![1].replace(/^          /gmu, '')
+}
+
+const classifier = () => workflowBlock('Classify validation scope')
+  .replace("evidence_scope='${{ steps.evidence.outputs.scope }}'", 'evidence_scope="$EVIDENCE_SCOPE"')
+
+const evidenceEligibility = () => workflowBlock('Guard reusable evidence trust boundary')
+
+const docsValidator = () => {
+  const workflow = readFileSync(workflowPath, 'utf8')
+  const match = workflow.match(/          python3 - <<'PY'\n([\s\S]*?)\n          PY/u)
+  expect(match?.[1]).toBeTruthy()
+  return match![1].replace(/^          /gmu, '')
+}
 
 describe('Avatar SDK CI workflow', () => {
-  it('validates pull-request integration trees once and retains a full manual path', () => {
+  it('keeps the required identity behind validation and produces evidence in an isolated job', () => {
     const workflow = readFileSync(workflowPath, 'utf8')
 
-    expect(workflow).toMatch(/^on:\n  pull_request:[\s\S]*^  push:\n    branches: \[main\][\s\S]*^  workflow_dispatch:/mu)
-    expect(workflow).toContain('name: build-test-pack')
-    expect(workflow).toContain("if [[ \"$EVENT_NAME\" != workflow_dispatch ]]")
-    expect(workflow).toContain('scope=full')
-    expect(workflow).toContain("steps.scope.outputs.scope != 'documentation'")
+    expect(workflow).toMatch(/^name: Avatar SDK CI$/mu)
+    expect(workflow).toMatch(/^  sdk:\n    name: build-test-pack\n    needs: validate\n    if: always\(\)/mu)
+    expect(workflow).toContain("if [[ \"$VALIDATION_RESULT\" != success ]]")
+    expect(workflow).toContain("run.name !== 'Avatar SDK CI'")
+    expect(workflow).toContain("run.path !== '.github/workflows/sdk-ci.yml'")
+    expect(workflow).toContain('run.head_sha !== headSha')
+    expect(workflow).toContain('integration.parents[0]?.sha !== baseSha')
+    expect(workflow).toContain('integration.parents[1]?.sha !== headSha')
+    expect(workflow).toContain('uses: actions/upload-artifact@v4')
+    expect(workflow).toContain('name: avatar-pr-ci-evidence-${{ github.run_id }}-${{ github.run_attempt }}')
+    expect(workflow).toContain('retention-days: 2')
+    expect(workflow).toContain('if-no-files-found: error')
+    expect(workflow).toMatch(/^permissions:\n  actions: read\n  contents: read\n  pull-requests: read$/mu)
+
+    const sdkJob = workflow.slice(workflow.indexOf('\n  sdk:'))
+    expect(sdkJob).not.toContain('actions/checkout')
+    expect(sdkJob).not.toContain('scripts/verify-pr-ci-evidence.mjs')
+  })
+
+  it('executes the classifier matrix with cover precedence and fail-closed events', () => {
+    const root = mkdtempSync(join(tmpdir(), 'avatar-sdk-scope-'))
+    git(root, ['init', '-b', 'main'])
+    mkdirSync(join(root, 'src'))
+    mkdirSync(join(root, 'scripts'))
+    mkdirSync(join(root, '.github', 'assets'), { recursive: true })
+    mkdirSync(join(root, '.github', 'workflows'), { recursive: true })
+    const covers = [
+      'avatar-cover-light-en.jpg',
+      'avatar-cover-dark-en.jpg',
+      'avatar-cover-light-zh-Hans.jpg',
+      'avatar-cover-dark-zh-Hans.jpg'
+    ]
+    writeFileSync(join(root, 'README.md'), 'base\n')
+    writeFileSync(join(root, 'src', 'code.ts'), 'base\n')
+    writeFileSync(join(root, 'scripts', 'readme-cover.html'), '<!doctype html>\n')
+    for (const cover of covers) writeFileSync(join(root, '.github', 'assets', cover), 'cover\n')
+    writeFileSync(join(root, '.github', 'assets', 'bear-breed-profiles.png'), 'bear\n')
+    writeFileSync(join(root, '.github', 'workflows', 'other.yml'), 'name: other\n')
+    const base = commit(root, 'base')
+
+    const make = (name: string, mutate: () => void) => {
+      git(root, ['checkout', '--detach', base])
+      mutate()
+      return commit(root, name)
+    }
+    const coverHeads = covers.map(cover => make(cover, () => writeFileSync(join(root, '.github', 'assets', cover), `new ${cover}\n`)))
+    const docs = make('docs', () => writeFileSync(join(root, 'README.md'), 'docs\n'))
+    const source = make('source', () => writeFileSync(join(root, 'src', 'code.ts'), 'source\n'))
+    const coverHtml = make('cover html', () => writeFileSync(join(root, 'scripts', 'readme-cover.html'), '<script>bad</script>\n'))
+    const bear = make('bear', () => writeFileSync(join(root, '.github', 'assets', 'bear-breed-profiles.png'), 'changed\n'))
+    const otherGithub = make('other github', () => writeFileSync(join(root, '.github', 'workflows', 'other.yml'), 'name: changed\n'))
+    const unknown = make('unknown', () => writeFileSync(join(root, 'unknown.txt'), 'unknown\n'))
+    const deletion = make('delete', () => rmSync(join(root, 'src', 'code.ts')))
+    const rename = make('rename', () => git(root, ['mv', 'README.md', 'README-renamed.md']))
+    const executable = make('mode', () => chmodSync(join(root, 'README.md'), 0o755))
+    const symlink = make('symlink', () => {
+      rmSync(join(root, 'README.md'))
+      symlinkSync('src/code.ts', join(root, 'README.md'))
+    })
+    const mixed = make('mixed', () => {
+      writeFileSync(join(root, 'README.md'), 'docs\n')
+      writeFileSync(join(root, 'src', 'code.ts'), 'source\n')
+    })
+
+    const run = (event: string, head: string, evidence = 'reused-pr-ci') => {
+      const output = join(root, `out-${event}-${head.slice(0, 8)}-${evidence}`)
+      rmSync(output, { force: true })
+      execFileSync('bash', ['-c', classifier()], {
+        cwd: root,
+        env: { ...process.env, EVENT_NAME: event, BASE_SHA: base, HEAD_SHA: head, EVIDENCE_SCOPE: evidence, GITHUB_OUTPUT: output },
+        stdio: 'pipe'
+      })
+      return readFileSync(output, 'utf8').match(/^scope=(.*)$/m)?.[1]
+    }
+
+    for (const cover of coverHeads) expect(run('pull_request', cover, 'full')).toBe('docs-assets')
+    expect(run('pull_request', docs, 'full')).toBe('docs-assets')
+    expect(run('pull_request', source, 'full')).toBe('full')
+    for (const cover of coverHeads) expect(run('push', cover)).toBe('docs-assets')
+    expect(run('push', source)).toBe('reused-pr-ci')
+    expect(run('push', source, 'full')).toBe('full')
+    expect(run('push', docs, 'full')).toBe('full')
+    expect(run('workflow_dispatch', coverHeads[0])).toBe('full')
+    for (const head of [coverHtml, bear, otherGithub, unknown, deletion, rename, executable, symlink, mixed]) {
+      expect(run('push', head)).toBe('full')
+    }
+  })
+
+  it('forces full evidence eligibility when the workflow or consumer changes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'avatar-evidence-boundary-'))
+    git(root, ['init', '-b', 'main'])
+    mkdirSync(join(root, '.github', 'workflows'), { recursive: true })
+    mkdirSync(join(root, 'scripts'))
+    mkdirSync(join(root, 'src'))
+    writeFileSync(join(root, '.github', 'workflows', 'sdk-ci.yml'), 'base\n')
+    writeFileSync(join(root, 'scripts', 'verify-pr-ci-evidence.mjs'), 'base\n')
+    writeFileSync(join(root, 'src', 'code.ts'), 'base\n')
+    const base = commit(root, 'base')
+    const make = (path: string) => {
+      git(root, ['checkout', '--detach', base])
+      writeFileSync(join(root, path), 'changed\n')
+      return commit(root, path)
+    }
+    const source = make('src/code.ts')
+    const workflow = make('.github/workflows/sdk-ci.yml')
+    const helper = make('scripts/verify-pr-ci-evidence.mjs')
+    const run = (head: string) => {
+      const output = join(root, `eligibility-${head.slice(0, 8)}`)
+      execFileSync('bash', ['-c', evidenceEligibility()], {
+        cwd: root,
+        env: { ...process.env, EVENT_NAME: 'push', BASE_SHA: base, HEAD_SHA: head, GITHUB_OUTPUT: output },
+        stdio: 'pipe'
+      })
+      return readFileSync(output, 'utf8').match(/^allowed=(.*)$/m)?.[1]
+    }
+    expect(run(source)).toBe('true')
+    expect(run(workflow)).toBe('false')
+    expect(run(helper)).toBe('false')
+  })
+
+  it('validates all four real README cover links during a cover-only update', () => {
+    const root = mkdtempSync(join(tmpdir(), 'avatar-cover-validator-'))
+    git(root, ['init', '-b', 'main'])
+    mkdirSync(join(root, '.github', 'assets'), { recursive: true })
+    const en = ['.github/assets/avatar-cover-dark-en.jpg', '.github/assets/avatar-cover-light-en.jpg']
+    const zh = ['.github/assets/avatar-cover-dark-zh-Hans.jpg', '.github/assets/avatar-cover-light-zh-Hans.jpg']
+    writeFileSync(join(root, 'README.md'), en.map(path => `<img src="${path}">`).join('\n'))
+    writeFileSync(join(root, 'README.zh-Hans.md'), zh.map(path => `<img src="${path}">`).join('\n'))
+    for (const image of [...en, ...zh]) writeFileSync(join(root, image), Buffer.from([0xff, 0xd8, 0xff, 0xd9]))
+    const base = commit(root, 'base')
+    writeFileSync(join(root, en[0]), Buffer.from([0xff, 0xd8, 0xff, 0x00, 0xff, 0xd9]))
+    const valid = commit(root, 'cover update')
+    const execute = (head: string) => execFileSync('python3', ['-c', docsValidator()], {
+      cwd: root,
+      env: { ...process.env, BASE_SHA: base, HEAD_SHA: head },
+      stdio: 'pipe'
+    })
+    expect(() => execute(valid)).not.toThrow()
+
+    writeFileSync(join(root, 'README.md'), `<img src="${en[0]}">\n${en[1]}`)
+    writeFileSync(join(root, en[1]), Buffer.from([0xff, 0xd8, 0xff, 0x01, 0xff, 0xd9]))
+    const missingLink = commit(root, 'missing link')
+    expect(() => execute(missingLink)).toThrow()
+  })
+
+  it('keeps the repository READMEs linked to every required cover', () => {
+    const english = readFileSync(new URL('../README.md', import.meta.url), 'utf8')
+    const chinese = readFileSync(new URL('../README.zh-Hans.md', import.meta.url), 'utf8')
+    expect(english).toContain('.github/assets/avatar-cover-dark-en.jpg')
+    expect(english).toContain('.github/assets/avatar-cover-light-en.jpg')
+    expect(chinese).toContain('.github/assets/avatar-cover-dark-zh-Hans.jpg')
+    expect(chinese).toContain('.github/assets/avatar-cover-light-zh-Hans.jpg')
   })
 })

--- a/scripts/verify-pr-ci-evidence.mjs
+++ b/scripts/verify-pr-ci-evidence.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process'
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const SHA = /^[0-9a-f]{40}$/iu
+const WORKFLOW_NAME = 'Avatar SDK CI'
+const WORKFLOW_PATH = '.github/workflows/sdk-ci.yml'
+const JOB_NAME = 'build-test-pack'
+const ARTIFACT_PREFIX = 'avatar-pr-ci-evidence-'
+const PAGE_SIZE = 100
+const MAX_PAGES = 3
+const MAX_REQUESTS = 30
+const MAX_ARTIFACT_BYTES = 1024 * 1024
+const MAX_EVIDENCE_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+const isSha = value => typeof value === 'string' && SHA.test(value)
+const isInteger = value => Number.isInteger(value) && value > 0
+const sameRepository = (actual, expected) => actual?.id === expected?.id && actual?.full_name === expected?.full_name
+const artifactName = run => `${ARTIFACT_PREFIX}${run.id}-${run.run_attempt}`
+
+export const createApi = ({ timeoutMs = 10_000 } = {}) => async (url, token) => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'x-github-api-version': '2022-11-28'
+      }
+    })
+    if (!response.ok) throw new Error(`GitHub API returned ${response.status}`)
+    return response.json()
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export const collectPages = async ({ url, key, requestJson, token, maxPages = MAX_PAGES }) => {
+  const collected = []
+  let expectedTotal
+  for (let page = 1; page <= maxPages; page += 1) {
+    const separator = url.includes('?') ? '&' : '?'
+    const response = await requestJson(`${url}${separator}per_page=${PAGE_SIZE}&page=${page}`, token)
+    const items = response?.[key]
+    if (!Array.isArray(items) || !Number.isInteger(response.total_count) || response.total_count < 0) {
+      throw new Error(`Invalid paginated ${key} response`)
+    }
+    if (expectedTotal === undefined) expectedTotal = response.total_count
+    if (response.total_count !== expectedTotal || response.total_count > maxPages * PAGE_SIZE) {
+      throw new Error(`Unbounded or changing ${key} pagination`)
+    }
+    collected.push(...items)
+    if (collected.length >= expectedTotal || items.length < PAGE_SIZE) break
+  }
+  if (collected.length !== expectedTotal) throw new Error(`Incomplete ${key} pagination`)
+  return collected
+}
+
+const fetchArchive = async ({ url, token, timeoutMs = 10_000 }) => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const apiResponse = await fetch(url, {
+      redirect: 'manual',
+      signal: controller.signal,
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'x-github-api-version': '2022-11-28'
+      }
+    })
+    if (apiResponse.status !== 302) throw new Error(`Artifact download API returned ${apiResponse.status}`)
+    const location = apiResponse.headers.get('location')
+    if (!location) throw new Error('Artifact download redirect was missing')
+
+    const archiveResponse = await fetch(location, { signal: controller.signal })
+    if (!archiveResponse.ok) throw new Error(`Artifact storage returned ${archiveResponse.status}`)
+    const declaredLength = Number(archiveResponse.headers.get('content-length'))
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_ARTIFACT_BYTES) throw new Error('Artifact archive is too large')
+    if (!archiveResponse.body) throw new Error('Artifact archive body is missing')
+    const chunks = []
+    let size = 0
+    for await (const chunk of archiveResponse.body) {
+      size += chunk.byteLength
+      if (size > MAX_ARTIFACT_BYTES) throw new Error('Artifact archive is too large')
+      chunks.push(Buffer.from(chunk))
+    }
+    if (size === 0) throw new Error('Artifact archive size is invalid')
+    return Buffer.concat(chunks, size)
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export const downloadEvidence = async ({ artifact, apiUrl, repository, token }) => {
+  const directory = mkdtempSync(join(tmpdir(), 'avatar-pr-ci-evidence-'))
+  const archivePath = join(directory, 'evidence.zip')
+  try {
+    const bytes = await fetchArchive({
+      url: `${apiUrl}/repos/${repository}/actions/artifacts/${artifact.id}/zip`,
+      token
+    })
+    writeFileSync(archivePath, bytes, { flag: 'wx', mode: 0o600 })
+    const files = execFileSync('unzip', ['-Z1', archivePath], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      maxBuffer: 64 * 1024
+    }).trim().split('\n').filter(Boolean)
+    if (files.length !== 1 || files[0] !== 'pr-ci-evidence.json') throw new Error('Artifact archive contents are invalid')
+    const json = execFileSync('unzip', ['-p', archivePath, 'pr-ci-evidence.json'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      maxBuffer: MAX_ARTIFACT_BYTES
+    })
+    return JSON.parse(json)
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+export const officialRunCandidates = ({ runs, workflow, pullRequest, repository }) => runs.filter(run =>
+  isInteger(run?.id) && isInteger(run?.run_attempt) &&
+  run.workflow_id === workflow.id && run.name === WORKFLOW_NAME && run.path === WORKFLOW_PATH &&
+  run.event === 'pull_request' && run.status === 'completed' && run.conclusion === 'success' &&
+  run.head_sha === pullRequest.head.sha &&
+  run.repository?.id === repository.id && run.repository?.full_name === repository.full_name &&
+  run.head_repository?.id === pullRequest.head.repo.id && run.head_repository?.full_name === pullRequest.head.repo.full_name
+)
+
+export const validateEvidence = ({ evidence, repository, workflow, run, pullRequest, artifact, mainCommit, integrationCommit, now }) => {
+  const generatedAt = Date.parse(evidence?.generated_at)
+  const artifactCreatedAt = Date.parse(artifact?.created_at)
+  const artifactExpiresAt = Date.parse(artifact?.expires_at)
+  if (evidence?.schema_version !== 1 || !Number.isFinite(generatedAt) ||
+      !Number.isFinite(artifactCreatedAt) || !Number.isFinite(artifactExpiresAt) ||
+      artifact.expired !== false || artifactCreatedAt > now || artifactExpiresAt <= now ||
+      now - artifactCreatedAt > MAX_EVIDENCE_AGE_MS || Math.abs(generatedAt - artifactCreatedAt) > 15 * 60 * 1000) return false
+
+  if (!sameRepository(evidence.repository, repository) ||
+      evidence.workflow?.id !== workflow.id || evidence.workflow?.name !== WORKFLOW_NAME || evidence.workflow?.path !== WORKFLOW_PATH ||
+      evidence.run?.id !== run.id || evidence.run?.attempt !== run.run_attempt || evidence.run?.event !== 'pull_request' ||
+      evidence.run?.head_sha !== run.head_sha ||
+      evidence.pull_request?.number !== pullRequest.number ||
+      evidence.pull_request?.base?.repository?.id !== repository.id || evidence.pull_request?.base?.repository?.full_name !== repository.full_name ||
+      evidence.pull_request?.head?.repository?.id !== pullRequest.head.repo.id ||
+      evidence.pull_request?.head?.repository?.full_name !== pullRequest.head.repo.full_name ||
+      evidence.pull_request?.head?.sha !== pullRequest.head.sha || !isSha(evidence.pull_request?.base?.sha)) return false
+
+  const integration = evidence.integration
+  return isSha(integration?.sha) && isSha(integration?.tree) &&
+    Array.isArray(integration.parents) && integration.parents.length === 2 &&
+    integration.parents[0] === evidence.pull_request.base.sha && integration.parents[1] === evidence.pull_request.head.sha &&
+    integrationCommit?.sha === integration.sha && integrationCommit?.commit?.tree?.sha === integration.tree &&
+    Array.isArray(integrationCommit?.parents) && integrationCommit.parents.length === 2 &&
+    integrationCommit.parents[0]?.sha === integration.parents[0] && integrationCommit.parents[1]?.sha === integration.parents[1] &&
+    mainCommit?.sha != null && isSha(mainCommit.commit?.tree?.sha) && mainCommit.commit.tree.sha === integration.tree &&
+    Array.isArray(mainCommit.parents) && mainCommit.parents.length >= 1 && mainCommit.parents[0]?.sha === integration.parents[0]
+}
+
+export const evaluateCandidate = async ({ repository, workflow, run, pullRequest, artifact, mainCommit, requestJson, readEvidence, root, token, now }) => {
+  const jobs = await collectPages({
+    url: `${root}/actions/runs/${run.id}/attempts/${run.run_attempt}/jobs?filter=latest`,
+    key: 'jobs',
+    requestJson,
+    token
+  })
+  const requiredJobs = jobs.filter(job => job?.name === JOB_NAME)
+  if (requiredJobs.length !== 1 || requiredJobs[0].status !== 'completed' || requiredJobs[0].conclusion !== 'success' ||
+      (requiredJobs[0].run_attempt != null && requiredJobs[0].run_attempt !== run.run_attempt)) {
+    return { reuse: false, reason: 'required-job-not-successful' }
+  }
+
+  const expectedName = artifactName(run)
+  const exactArtifacts = artifact.filter(item => item?.name === expectedName)
+  if (exactArtifacts.length !== 1) return { reuse: false, reason: 'ambiguous-or-missing-evidence-artifact' }
+  const selected = exactArtifacts[0]
+  if (!isInteger(selected.id) || selected.workflow_run?.id !== run.id ||
+      selected.workflow_run?.repository_id !== repository.id ||
+      selected.workflow_run?.head_repository_id !== pullRequest.head.repo.id ||
+      selected.workflow_run?.head_sha !== pullRequest.head.sha) {
+    return { reuse: false, reason: 'artifact-official-identity-mismatch' }
+  }
+
+  const evidence = await readEvidence(selected)
+  if (!isSha(evidence?.integration?.sha)) return { reuse: false, reason: 'invalid-evidence-json' }
+  const integrationCommit = await requestJson(`${root}/commits/${evidence.integration.sha}`, token)
+  if (!validateEvidence({ evidence, repository, workflow, run, pullRequest, artifact: selected, mainCommit, integrationCommit, now })) {
+    return { reuse: false, reason: 'evidence-content-mismatch' }
+  }
+  return { reuse: true, reason: 'exact-pr-ci-evidence', run: { id: run.id, attempt: run.run_attempt }, artifact: { id: selected.id } }
+}
+
+export const verify = async ({
+  env = process.env,
+  requestJson: rawRequestJson = createApi(),
+  readEvidence,
+  now = Date.now()
+} = {}) => {
+  if (env.GITHUB_EVENT_NAME !== 'push' || env.GITHUB_REF !== 'refs/heads/main') return { reuse: false, reason: 'not-a-main-push' }
+  if (!isSha(env.GITHUB_SHA) || !env.GITHUB_REPOSITORY || !env.GITHUB_TOKEN || !isInteger(Number(env.GITHUB_REPOSITORY_ID))) {
+    return { reuse: false, reason: 'missing-trusted-context' }
+  }
+
+  let requestCount = 0
+  const requestJson = async (...args) => {
+    requestCount += 1
+    if (requestCount > MAX_REQUESTS) throw new Error('GitHub API request budget exceeded')
+    return rawRequestJson(...args)
+  }
+  const apiUrl = env.GITHUB_API_URL || 'https://api.github.com'
+  const root = `${apiUrl}/repos/${env.GITHUB_REPOSITORY}`
+  const repository = { id: Number(env.GITHUB_REPOSITORY_ID), full_name: env.GITHUB_REPOSITORY }
+  const token = env.GITHUB_TOKEN
+
+  try {
+    const associated = await requestJson(`${root}/commits/${env.GITHUB_SHA}/pulls?per_page=100`, token)
+    if (!Array.isArray(associated)) return { reuse: false, reason: 'invalid-associated-pr-response' }
+    const exactPullRequests = associated.filter(pullRequest =>
+      isInteger(pullRequest?.number) && pullRequest.merged_at && pullRequest.merge_commit_sha === env.GITHUB_SHA &&
+      pullRequest.base?.ref === 'main' && sameRepository(pullRequest.base?.repo, repository) &&
+      isSha(pullRequest.head?.sha) && isInteger(pullRequest.head?.repo?.id) && typeof pullRequest.head.repo.full_name === 'string'
+    )
+    if (exactPullRequests.length !== 1) return { reuse: false, reason: 'ambiguous-or-no-associated-pr' }
+    const pullRequest = exactPullRequests[0]
+
+    const [workflows, mainCommit] = await Promise.all([
+      collectPages({ url: `${root}/actions/workflows`, key: 'workflows', requestJson, token }),
+      requestJson(`${root}/commits/${env.GITHUB_SHA}`, token)
+    ])
+    const exactWorkflows = workflows.filter(item => item?.name === WORKFLOW_NAME && item?.path === WORKFLOW_PATH && isInteger(item.id))
+    if (exactWorkflows.length !== 1) return { reuse: false, reason: 'workflow-identity-mismatch' }
+    const workflow = exactWorkflows[0]
+
+    const runs = await collectPages({
+      url: `${root}/actions/workflows/${workflow.id}/runs?event=pull_request&head_sha=${pullRequest.head.sha}`,
+      key: 'workflow_runs',
+      requestJson,
+      token
+    })
+    const candidates = officialRunCandidates({ runs, workflow, pullRequest, repository })
+    if (candidates.length !== 1) return { reuse: false, reason: 'ambiguous-or-missing-successful-run' }
+    const run = candidates[0]
+
+    const artifacts = await collectPages({
+      url: `${root}/actions/runs/${run.id}/artifacts`,
+      key: 'artifacts',
+      requestJson,
+      token
+    })
+    const evidenceReader = readEvidence || (artifact => downloadEvidence({ artifact, apiUrl, repository: env.GITHUB_REPOSITORY, token }))
+    return await evaluateCandidate({
+      repository,
+      workflow,
+      run,
+      pullRequest,
+      artifact: artifacts,
+      mainCommit,
+      requestJson,
+      readEvidence: evidenceReader,
+      root,
+      token,
+      now
+    })
+  } catch (error) {
+    const detail = error?.name === 'AbortError' ? 'request timed out' : String(error?.message || 'unknown failure').replace(/https?:\/\/\S+/gu, '<redacted-url>')
+    console.warn(`Unable to establish reusable PR CI evidence: ${detail}`)
+    return { reuse: false, reason: 'evidence-api-download-or-parse-failure' }
+  }
+}
+
+export const output = (result, target = process.env.GITHUB_OUTPUT) => {
+  if (target) appendFileSync(target, `scope=${result.reuse ? 'reused-pr-ci' : 'full'}\nevidence_reason=${result.reason}\n`)
+  console.log(`PR CI evidence: ${result.reuse ? 'reused' : 'full fallback'} (${result.reason})`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) verify().then(output)


### PR DESCRIPTION
## Summary

- Recompose Avatar SDK CI evidence v2 on protected `main` at `45dc71e0993494a66f29296ad1b79e5c1e591107`.
- Harden fail-closed pull-request evidence validation while preserving required `build-test-pack` identity and the existing workflow contract.
- The first post-merge `Avatar SDK CI` run is intentionally full because the workflow and evidence helper changed.

## Hosted verification expectations

- `validate-sdk-ci` must succeed on the new PR head.
- Required `build-test-pack` must execute on a fresh runner and succeed; it must not be skipped.
- The attempt-scoped evidence artifact must be unique, retained for 2 days, and bind the official workflow run, head SHA, integration parents/tree, and base/head repositories.
- The protected-main post-merge CI run must succeed before `Deploy Avatar` consumes its exact SHA.

## Risk and rollout

- Ambiguous, stale, expired, malformed, oversized, or mismatched hosted evidence fails closed; required checks are not weakened.
- The old PR artifact based on `3a624059dc614c94678e475216b1cfaa61a877e9` is expected to be rejected against the new main. The prospective merge model was validated locally and is not a substitute for hosted evidence.
- After this PR, run a separate source-only hosted canary before relying on `reused-pr-ci` in production.

## Validation

- Local evidence/workflow/deploy and new-main regression tests: 59 passed.
- Root and npm typechecks, all four SDK builds/typechecks, Node syntax, Ruby YAML duplicate-key/safe parse, and `git diff --check` passed.
- No npm publish, tag, ruleset, settings, environment, secret, permission, or package-byte changes.
