### PR TITLE
docs: correct PR #21 contributor attribution

### DIFF
--- a/artifacts/pr21-adaptation/REPORT.md
+++ b/artifacts/pr21-adaptation/REPORT.md
@@ -5,8 +5,8 @@
 - Source PR: `oneworks-ai/avatar#21`, branch source `xxchan/avatar:otter-preset`.
 - Source head: `04693016c1e1bb9b2f592cf857450f8412e8de93`.
 - Source commits: `d700397`, `e211c42`, `ce45579`, `aba646d`, `7344d2a`, `0469301`.
-- Author credit: `@xxchan`, `exe.dev user <exedev@xxwork.exe.xyz>`.
-- If this local adaptation is later committed, retain: `Co-authored-by: exe.dev user <exedev@xxwork.exe.xyz>`.
+- Author credit: `@xxchan`, original commit identity `exe.dev user <exedev@xxwork.exe.xyz>`.
+- GitHub does not associate the original email with `@xxchan`; integration commits must use the linked trailer `Co-authored-by: xxchan <37948597+xxchan@users.noreply.github.com>` while retaining the original identity above as provenance.
 
 ## Adopted
 

--- a/artifacts/pr21-adaptation/source-attribution.json
+++ b/artifacts/pr21-adaptation/source-attribution.json
@@ -1,10 +1,12 @@
 {
   "author": {
     "email": "exedev@xxwork.exe.xyz",
+    "githubLinkedEmail": "37948597+xxchan@users.noreply.github.com",
     "name": "exe.dev user",
     "username": "@xxchan"
   },
-  "coAuthoredBy": "Co-authored-by: exe.dev user <exedev@xxwork.exe.xyz>",
+  "coAuthoredBy": "Co-authored-by: xxchan <37948597+xxchan@users.noreply.github.com>",
+  "originalCoAuthoredBy": "Co-authored-by: exe.dev user <exedev@xxwork.exe.xyz>",
   "commits": [
     "d7003970e703a93892050999718cc705fe8bdad4",
     "e211c42b82c1194eff310c594997763637ae1095",


### PR DESCRIPTION
Correct the attribution metadata for the selectively integrated PR #21 work.

The original commits used exedev@xxwork.exe.xyz, which GitHub does not associate with @xxchan. This preserves that original identity as provenance and adds the account-linked noreply address so GitHub can recognize the contributor.

Source: #21
Integrated implementation: #28

Co-authored-by: xxchan <37948597+xxchan@users.noreply.github.com>