### PR TITLE
chore: map PR #21 contributor identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+xxchan <37948597+xxchan@users.noreply.github.com> exe.dev user <exedev@xxwork.exe.xyz>


### PR DESCRIPTION
Map the original PR #21 commit identity to the GitHub-linked @xxchan noreply address.

This PR must be rebase-merged rather than squash-merged so the linked commit author is preserved and can appear in the repository Contributors list.

Source contribution: #21
Integrated implementation: #28