### PR TITLE
test(web): preserve safe custom-element attribute defaults

### DIFF
--- a/packages/web/__tests__/elements.spec.ts
+++ b/packages/web/__tests__/elements.spec.ts
@@ -72,6 +72,29 @@ describe('OneWorks Avatar custom elements', () => {
     expect(customElements.get('oneworks-avatar-editor')).toBe(OneWorksAvatarEditorElement)
   })
 
+  it('normalizes custom-element attributes to safe public options', () => {
+    registerAvatarElements()
+    const avatar = document.createElement('oneworks-avatar')
+    const editor = document.createElement('oneworks-avatar-editor')
+    mounted.push(avatar, editor)
+    avatar.setAttribute('autoplay', '')
+    avatar.setAttribute('interactive', '')
+    avatar.setAttribute('theme', 'untrusted')
+    editor.setAttribute('locale', 'untrusted')
+    editor.setAttribute('theme', 'dark')
+    document.body.append(avatar, editor)
+
+    expect(mounts.createAvatar.mock.calls.at(-1)?.[1]).toEqual(expect.objectContaining({
+      autoplay: true,
+      interactive: true,
+      theme: 'system'
+    }))
+    expect(mounts.createAvatarEditor.mock.calls.at(-1)?.[1]).toEqual(expect.objectContaining({
+      locale: 'en',
+      theme: 'dark'
+    }))
+  })
+
   it('preserves runtime and editor definitions across disconnect and reconnect', () => {
     registerAvatarElements()
     const definition = {


### PR DESCRIPTION
## Summary

- Add a regression test for the public `@oneworks/avatar-web` custom-element attribute boundary.
- Verify unsupported runtime themes fall back to `system`, unsupported editor locales fall back to `en`, boolean attributes preserve HTML presence semantics, and valid `dark` theme propagates.

## Why this is safe

This is a source-only safety-boundary regression in the Web Components adapter. The change is one regular `packages/` test file; no CI trust-boundary, evidence verifier, deploy, npm, version, lockfile, generated asset, or documentation file is changed.

## Hosted reuse canary

The PR must receive the normal full Avatar SDK CI validation and produce its exact integration-tree evidence artifact. If this exact integration tree is squash-merged without base/tree/first-parent drift, protected main may reuse that artifact as `reused-pr-ci`. Direct/manual events, trust-file changes, tampered evidence, and identity/tree/parent mismatches must remain full or fail-closed.

No hosted workflow or production reuse result has been observed yet; this PR body does not claim one.

## Validation

- `pnpm exec vitest run packages/web/__tests__/elements.spec.ts packages/web/__tests__/lifecycle.spec.ts packages/web/__tests__/pickers.spec.ts`
- `pnpm exec vitest run __tests__/prCiEvidence.spec.ts`
- `pnpm typecheck`
- Node/YAML syntax and `git diff --check`

## Review scope

- Base locked to live protected `main` at `d0b7936873f0e855b1724577b771196450218c9a` before branch creation.
- One-file regular A/M diff; no CI/release-path edits.
- Follow-up acceptance requires PR full validation, exact artifact identity, squash merge with unchanged base/tree/first parent, main `reused-pr-ci`, and Deploy Avatar exact-SHA success.