### PR TITLE
docs: explain adaptive README cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
   <img alt="OneWorks Avatar — a growing gallery of geometric 3D avatars and pixel styles" src=".github/assets/avatar-cover-light-en.jpg" width="1600">
 </picture>
 
+This cover automatically follows your system’s light or dark color scheme.
+
 Create, animate, and export a geometric 3D avatar directly in your browser.
 
 ## Quick start

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -8,6 +8,8 @@
   <img alt="OneWorks Avatar——不断扩展的几何 3D 头像与像素风格" src=".github/assets/avatar-cover-light-zh-Hans.jpg" width="1600">
 </picture>
 
+此封面会自动跟随系统的浅色或深色配色方案。
+
 直接在浏览器中创建、制作动画并导出几何 3D 头像。
 
 ## 快速开始


### PR DESCRIPTION
## Summary / 摘要

- Clarifies in English and Simplified Chinese that the README cover follows the system light/dark color scheme.
- 说明 README 封面会自动跟随系统浅色/深色配色方案。

This is a hosted docs-assets validation only; no workflow or helper changes are included.
本 PR 仅用于托管 docs-assets 验证；不包含任何 workflow 或 helper 变更。

## Validation / 验证

- Local workflow classifier/docs validator: passed.
- Review: APPROVE; P0-P3 none.
- Experience Review: APPROVE; P0-P3 none.